### PR TITLE
Replace multi-scene setup with MayaScene

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,10 +24,10 @@
   const timeInput = document.getElementById("birth-time");
   const launchButton = document.getElementById("launch");
   const infoButton = document.getElementById("info");
-  const sceneToggle = document.getElementById("scene-toggle");
   const langToggle = document.getElementById("lang-toggle");
-  const sceneButtons = Array.from(sceneToggle.querySelectorAll("[data-scene]"));
-  const langButtons = Array.from(langToggle.querySelectorAll("[data-lang]"));
+  const langButtons = langToggle
+    ? Array.from(langToggle.querySelectorAll("[data-lang]"))
+    : [];
 
   const modal = document.getElementById("info-modal");
   const modalOverlay = document.getElementById("modal-overlay");
@@ -41,11 +41,12 @@
   const fallbackHour = document.getElementById("fallback-hour");
   const fallbackMinute = document.getElementById("fallback-minute");
 
-  // --- 2. Дані сцен ---
-  const scenes = {
-    lissajous: window.lissajousScene,
-    rune: window.runeScene,
-  };
+  // --- 2. Єдина сцена MayaScene ---
+  const mayaSceneInstance = window.mayaScene;
+  if (!mayaSceneInstance) {
+    console.error("MayaScene не знайдена. Переконайтесь, що MayaScene.js підключено перед main.js.");
+    return;
+  }
 
   // --- 3. Глобальний стан ---
   const state = {
@@ -59,8 +60,7 @@
     designScale: 1,
     designOffsetX: 0,
     designOffsetY: 0,
-    activeSceneKey: "",
-    sceneInstance: null,
+    sceneInstance: mayaSceneInstance,
     runStartedAt: 0,
     lang: CONFIG.i18n.default,
     usingFallback: false,
@@ -134,14 +134,6 @@
       }
     }
     return CONFIG.i18n.default;
-  }
-
-  function detectInitialScene() {
-    const saved = getStored("scene");
-    if (saved && scenes[saved]) {
-      return saved;
-    }
-    return "lissajous";
   }
 
   function resetPerformanceTracker() {
@@ -219,19 +211,8 @@
     }
 
     updateLanguageButtons();
-    updateSceneButtons();
     updateCanvasSize();
     updateLaunchState();
-  }
-
-  function updateSceneButtons() {
-    sceneButtons.forEach((button) => {
-      if (button.dataset.scene === state.activeSceneKey) {
-        button.classList.add("is-active");
-      } else {
-        button.classList.remove("is-active");
-      }
-    });
   }
 
   function updateLanguageButtons() {
@@ -250,24 +231,6 @@
     }
     setStored("lang", lang);
     applyI18n(lang);
-  }
-
-  function setActiveScene(sceneKey, { forceRestart = false } = {}) {
-    if (!scenes[sceneKey]) return;
-    state.activeSceneKey = sceneKey;
-    state.sceneInstance = scenes[sceneKey];
-    setStored("scene", sceneKey);
-    updateSceneButtons();
-
-    if (state.sceneInstance && typeof state.sceneInstance.resize === "function") {
-      state.sceneInstance.resize(scenesDesignWidth, scenesDesignHeight);
-    }
-
-    if (state.isRunning || forceRestart) {
-      restartActiveScene({ force: true });
-    } else if (state.sceneInstance && typeof state.sceneInstance.resetModeLock === "function") {
-      state.sceneInstance.resetModeLock();
-    }
   }
 
   function getTodayParts() {
@@ -406,18 +369,10 @@
     });
   });
 
-  // --- 7. Вибір сцени ---
-  const initialSceneKey = detectInitialScene();
-  setActiveScene(initialSceneKey);
-
-  sceneButtons.forEach((button) => {
-    button.addEventListener("click", () => {
-      const { scene: sceneKey } = button.dataset;
-      if (sceneKey && sceneKey !== state.activeSceneKey) {
-        setActiveScene(sceneKey, { forceRestart: state.isRunning });
-      }
-    });
-  });
+  // --- 7. Підготовка єдиної сцени ---
+  if (state.sceneInstance && typeof state.sceneInstance.resize === "function") {
+    state.sceneInstance.resize(scenesDesignWidth, scenesDesignHeight);
+  }
 
   // --- 8. Робота з датами та запуском ---
   function getSelectedDate() {
@@ -594,13 +549,33 @@
   // --- 11. Перезапуск сцени ---
   function initializeScene(seed) {
     if (!state.sceneInstance) return;
-    const seedInt = window.hashStringToInt32(seed);
-    const prng = window.makePrng(seedInt);
+    const seedInt =
+      typeof window.hashStringToInt32 === "function" ? window.hashStringToInt32(seed) : 0;
+    const prng = typeof window.makePrng === "function" ? window.makePrng(seedInt) : null;
     if (typeof state.sceneInstance.resetModeLock === "function") {
       state.sceneInstance.resetModeLock();
     }
-    state.sceneInstance.init(seed, prng);
-    state.sceneInstance.resize(scenesDesignWidth, scenesDesignHeight);
+    if (typeof state.sceneInstance.init === "function") {
+      // Передаємо seed та PRNG (якщо він створений), щоб сцена могла реагувати на вхідні дані.
+      state.sceneInstance.init(seed, prng);
+    } else {
+      // Якщо сцена не підтримує init, м'яко скидаємо базові таймери вручну.
+      if ("seed" in state.sceneInstance) {
+        state.sceneInstance.seed = seed;
+      }
+      if ("phase" in state.sceneInstance) {
+        state.sceneInstance.phase = "intro";
+      }
+      if ("time" in state.sceneInstance) {
+        state.sceneInstance.time = 0;
+      }
+      if ("startedAt" in state.sceneInstance) {
+        state.sceneInstance.startedAt = performance.now();
+      }
+    }
+    if (typeof state.sceneInstance.resize === "function") {
+      state.sceneInstance.resize(scenesDesignWidth, scenesDesignHeight);
+    }
     resetPerformanceTracker();
     state.currentSeed = seed;
     state.runStartedAt = performance.now();

--- a/assets/js/scenes/MayaScene.js
+++ b/assets/js/scenes/MayaScene.js
@@ -1,0 +1,108 @@
+// MayaScene відповідає за відображення календарної символіки майя.
+// Усі пояснення подані українською мовою, щоб навіть новачок міг простежити логіку.
+
+(() => {
+  "use strict";
+
+  if (!window.CONFIG) {
+    console.error(
+      "CONFIG не знайдено. Переконайтесь, що config.js завантажений перед MayaScene.js."
+    );
+    return;
+  }
+
+  const CONFIG = window.CONFIG;
+
+  class MayaScene {
+    constructor() {
+      // Зберігаємо розміри "дизайн-рамки" сцени. Спочатку беремо значення з конфігурації.
+      this.width = CONFIG.global.DESIGN_WIDTH;
+      this.height = CONFIG.global.DESIGN_HEIGHT;
+
+      // Локальні параметри часу, потрібні для етапів анімації.
+      this.time = 0;
+      this.phase = "intro";
+      this.startedAt = performance.now();
+      this.introDurationMs = CONFIG.global.INTRO_DURATION_MS;
+
+      // Додаємо поле для збереження поточного seed, якщо знадобиться у майбутньому.
+      this.seed = "";
+    }
+
+    /**
+     * Метод init викликається головним циклом при старті або перезапуску сцени.
+     * Тут ми скидаємо таймер та запам'ятовуємо seed для можливих майбутніх розрахунків.
+     */
+    init(seedStr) {
+      this.seed = seedStr || "";
+      this.time = 0;
+      this.phase = "intro";
+      this.startedAt = performance.now();
+    }
+
+    /**
+     * Під час зміни розміру канви ми пристосовуємо габарити сцени.
+     * Мінімальні обмеження у 200 пікселів гарантують, що ескіз не стиснеться до нуля.
+     */
+    resize(width, height) {
+      this.width = Math.max(width, 200);
+      this.height = Math.max(height, 200);
+    }
+
+    /**
+     * Оновлюємо внутрішній час сцени. Під час вступу відслідковуємо завершення
+     * вступної анімації, далі накопичуємо час для циклічних ефектів (на майбутнє).
+     */
+    update(dt, now) {
+      if (this.phase === "intro" && now - this.startedAt > this.introDurationMs) {
+        this.phase = "main";
+      } else if (this.phase === "main") {
+        this.time += dt;
+      }
+    }
+
+    /**
+     * Функція draw викликається щоразу, коли потрібно перемалювати сцену.
+     * Параметр progress показує, наскільки далеко просунулась вступна анімація.
+     */
+    draw(ctx, now) {
+      ctx.clearRect(0, 0, this.width, this.height);
+
+      const progress = Math.min(1, (now - this.startedAt) / this.introDurationMs);
+
+      // Малюємо гліф Cauac ("Буря"), що складається з хмари та блискавки.
+      this.drawCauac(ctx, progress);
+    }
+
+    /**
+     * Малювання гліфа майя "Cauac" (буря). Параметр progress (0..1)
+     * визначає, яка частина елементів уже з'явилась на полотні.
+     */
+    drawCauac(ctx, progress) {
+      ctx.save();
+      ctx.translate(this.width / 2, this.height / 2);
+      ctx.strokeStyle = "#0077cc";
+      ctx.lineWidth = 4;
+      ctx.lineCap = "round";
+
+      // Етап 1: плавно "виростає" силует хмари.
+      ctx.beginPath();
+      ctx.arc(0, -20, 40, Math.PI, Math.PI * (1 + progress));
+      ctx.stroke();
+
+      // Етап 2: після половини прогресу з'являється блискавка, що символізує бурю.
+      if (progress > 0.5) {
+        ctx.beginPath();
+        ctx.moveTo(0, 20);
+        ctx.lineTo(-15, 50);
+        ctx.lineTo(5, 70);
+        ctx.lineTo(-10, 100);
+        ctx.stroke();
+      }
+
+      ctx.restore();
+    }
+  }
+
+  window.mayaScene = new MayaScene();
+})();

--- a/index.html
+++ b/index.html
@@ -88,30 +88,6 @@
       <div class="top-bar__toggles">
         <div
           class="toggle-group"
-          id="scene-toggle"
-          role="group"
-          data-i18n-attr="aria-label"
-          data-i18n="sceneToggleAria"
-        >
-          <button
-            type="button"
-            class="toggle-button"
-            data-scene="lissajous"
-            data-i18n="sceneLissajous"
-          >
-            Ліссажу
-          </button>
-          <button
-            type="button"
-            class="toggle-button"
-            data-scene="rune"
-            data-i18n="sceneRune"
-          >
-            Руни
-          </button>
-        </div>
-        <div
-          class="toggle-group"
           id="lang-toggle"
           role="group"
           data-i18n-attr="aria-label"
@@ -167,8 +143,7 @@
 
     <script src="assets/js/config.js"></script>
     <script src="assets/js/utils/prng.js"></script>
-    <script src="assets/js/scenes/lissajous.js"></script>
-    <script src="assets/js/scenes/rune.js"></script>
+    <script src="assets/js/scenes/MayaScene.js"></script>
     <script src="assets/js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the previous multi-scene toggle logic with a single MayaScene instance handled directly in `main.js`
- remove the scene switcher UI from the homepage and load the new scene script instead of the old rune and lissajous scenes
- implement `MayaScene` that animates the Cauac glyph with a timed intro before the main animation phase

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26f73efd88320b802743fcb9b5f72