### PR TITLE
Add SymbolScene with adaptive UI and Mayan Cauac glyph

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,149 +1,35 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="uk">
-  <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-  <title>Aura — генеративна графіка</title>
-  <meta
-    name="description"
-    content="Aura — сервіс генеративної графіки. Створюйте унікальні візерунки на основі дати та часу народження."
-  />
-
-  <!-- Open Graph -->
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Aura — генеративна графіка" />
-  <meta
-    property="og:description"
-    content="Створюйте унікальні візерунки на основі дати та часу народження."
-  />
-  <meta property="og:image" content="https://aura.bit.city/preview.png" />
-  <meta property="og:url" content="https://aura.bit.city/" />
-
-  <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Aura — генеративна графіка" />
-  <meta
-    name="twitter:description"
-    content="Створюйте унікальні візерунки на основі дати та часу народження."
-  />
-  <meta name="twitter:image" content="https://aura.bit.city/preview.png" />
-
-  <!-- Canonical -->
-  <link rel="canonical" href="https://aura.bit.city/" />
-
-  <!-- Styles -->
-  <link rel="stylesheet" href="assets/css/style.css" />
-
-  <!-- Favicon (опційно) -->
-  <link rel="icon" href="assets/img/favicon.png" type="image/png" />
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <title>Calendars — Symbols</title>
+  <link rel="stylesheet" href="src/styles/theme.css" />
+  <link rel="stylesheet" href="src/styles/controls.css" />
 </head>
-
-  <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-R03TE5MZQ7"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-R03TE5MZQ7');
-</script>
-  <body>
-    <!-- Верхня панель керування, що залишається на місці під час прокрутки -->
-    <header class="top-bar">
-      <div class="top-bar__left" data-i18n="topBarLabel">Твоя дата народження</div>
-      <div class="top-bar__inputs" id="native-inputs">
-        <label class="visually-hidden" for="birth-date" data-i18n="dateLabel"
-          >Дата народження</label
-        >
-        <input id="birth-date" type="date" required />
-        <label class="visually-hidden" for="birth-time" data-i18n="timeLabel"
-          >Час народження</label
-        >
-        <input id="birth-time" type="time" step="60" />
-      </div>
-      <!-- Контейнер для фолбеків, показується лише якщо браузер не підтримує типи date/time -->
-      <div class="top-bar__inputs fallback-inputs" id="fallback-inputs" hidden>
-        <div class="fallback-group">
-          <label for="fallback-day" data-i18n="fallbackDayLabel">День</label>
-          <select id="fallback-day"></select>
-        </div>
-        <div class="fallback-group">
-          <label for="fallback-month" data-i18n="fallbackMonthLabel">Місяць</label>
-          <select id="fallback-month"></select>
-        </div>
-        <div class="fallback-group">
-          <label for="fallback-year" data-i18n="fallbackYearLabel">Рік</label>
-          <select id="fallback-year"></select>
-        </div>
-        <div class="fallback-group">
-          <label for="fallback-hour" data-i18n="fallbackHourLabel">Година</label>
-          <select id="fallback-hour"></select>
-        </div>
-        <div class="fallback-group">
-          <label for="fallback-minute" data-i18n="fallbackMinuteLabel">Хвилина</label>
-          <select id="fallback-minute"></select>
-        </div>
-      </div>
-      <div class="top-bar__toggles">
-        <div
-          class="toggle-group"
-          id="lang-toggle"
-          role="group"
-          data-i18n-attr="aria-label"
-          data-i18n="langToggleAria"
-        >
-          <button type="button" class="toggle-button" data-lang="ua" data-i18n="langUA">
-            UA
-          </button>
-          <button type="button" class="toggle-button" data-lang="en" data-i18n="langEN">
-            EN
-          </button>
-        </div>
-      </div>
-      <button id="launch" class="launch-button" disabled data-i18n="start">Запустити</button>
-      <button
-        id="info"
-        class="info-button"
-        aria-haspopup="dialog"
-        aria-controls="info-modal"
-        data-i18n-attr="aria-label"
-        data-i18n="infoAriaLabel"
-      >
-        ?
-      </button>
-    </header>
-
-    <!-- Головне полотно для рендеру сцен -->
-    <canvas id="scene" aria-hidden="true"></canvas>
-
-    <!-- Модальне вікно з поясненням задуму сайту -->
-    <div
-      class="modal"
-      id="info-modal"
-      hidden
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="info-modal-title"
-    >
-      <div class="modal__overlay" id="modal-overlay"></div>
-      <div class="modal__dialog">
-        <div class="modal__content">
-          <h2 class="modal__title" id="info-modal-title" data-i18n="aboutTitle">Про проєкт</h2>
-          <p class="modal__text" data-i18n-html="modalText">
-            Цей сайт відкриває приховану геометрію вашого життя.<br />
-            На основі дати й часу народження народжується унікальний візерунок — візуальний відбиток вашої присутності у
-            Всесвіті.<br />
-            Це не просто анімація, а символ початку й таємниці, який завжди буде лише вашим.
-          </p>
-          <button class="modal__close" id="modal-close" data-i18n="modalClose">Добре</button>
-        </div>
-      </div>
+<body>
+  <header id="controls" class="controls">
+    <div class="controls-left">
+      <label class="field">
+        <span class="label">Дата</span>
+        <input id="birthdate" type="date" />
+      </label>
+      <button id="runBtn" class="btn primary">Запустити</button>
     </div>
+    <div class="controls-right">
+      <div class="lang-switch" role="group" aria-label="Language">
+        <button class="lang" data-lang="uk" aria-pressed="true">UA</button>
+        <button class="lang" data-lang="en" aria-pressed="false">EN</button>
+      </div>
+      <button id="helpBtn" class="icon-btn" aria-label="Допомога">?</button>
+    </div>
+  </header>
 
-    <script src="assets/js/config.js"></script>
-    <script src="assets/js/utils/prng.js"></script>
-    <script src="assets/js/scenes/MayaScene.js"></script>
-    <script src="assets/js/main.js"></script>
-  </body>
+  <main id="stage">
+    <canvas id="canvas"></canvas>
+    <section id="desc" class="desc"></section>
+  </main>
+
+  <script type="module" src="main.js"></script>
+</body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,31 @@
+import { initControls } from './src/ui/controls.js';
+import { attachLayoutObservers } from './src/ui/layout.js';
+import { SymbolScene } from './src/scenes/SymbolScene.js';
+
+const canvas = document.getElementById('canvas');
+const desc = document.getElementById('desc');
+const scene = new SymbolScene(canvas, desc);
+
+function resize(){
+  scene.resize();
+  scene.draw();
+}
+attachLayoutObservers();
+window.addEventListener('resize', resize, { passive:true });
+resize();
+
+const controls = initControls({
+  onRun: (dateStr)=> {
+    scene.start(dateStr);
+  },
+  onLangChange: (lang)=> {
+    scene.setLang(lang);
+  },
+  onHelp: ()=> {
+    alert('Введи дату народження, обери мову та натисни «Запустити». Знак Майя промалюється анімовано. Єгипет і Кельти — найближчим часом.');
+  }
+});
+
+// автозапуск для демо
+scene.setLang(controls.getLang());
+scene.start(controls.getDate());

--- a/src/data/calendars.js
+++ b/src/data/calendars.js
@@ -1,0 +1,73 @@
+// Майя: 20 знаків у порядку Цолькін (0..19)
+const MAYAN_SIGNS = [
+  'imix','ik','akbal','kan','chicchan','kimi','manik','lamat','muluk','ok',
+  'chuen','eb','ben','ix','men','cib','caban','etznab','cauac','ahau'
+];
+
+// Юліанський день
+function toJDN(dateStr){
+  const d = new Date(dateStr);
+  const a = Math.floor((14 - (d.getMonth()+1))/12);
+  const y = d.getFullYear() + 4800 - a;
+  const m = (d.getMonth()+1) + 12*a - 3;
+  const jdn = d.getDate() + Math.floor((153*m + 2)/5) + 365*y + Math.floor(y/4) - Math.floor(y/100) + Math.floor(y/400) - 32045;
+  return jdn;
+}
+
+// GMT кореляція 584283
+export function getMayanSign(dateStr){
+  const jdn = toJDN(dateStr);
+  const count = jdn - 584283;
+  const signIndex = ((count % 20) + 20) % 20;
+  const tone = ((count % 13) + 13) % 13 + 1;
+  return {
+    signId: MAYAN_SIGNS[signIndex],
+    tone
+  };
+}
+
+// Плейсхолдери для Єгипту/Кельтів — додамо реальні мапи пізніше
+export function getEgyptSign(dateStr){
+  // Проста демонстраційна група: розіб'ємо місяць на діапазони
+  const m = new Date(dateStr).getMonth()+1;
+  const signId = (m===8||m===9) ? 'horus' : 'isis'; // тимчасово
+  return { signId };
+}
+
+export function getCelticTree(dateStr){
+  const d = new Date(dateStr);
+  const md = `${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+  // Умовна перевірка для Pine (24.08–02.09)
+  const pine = (md>='08-24' && md<='09-02');
+  return { signId: pine ? 'pine' : 'oak' }; // тимчасово
+}
+
+// Описові тексти — приклад для демо
+export const descriptions = {
+  mayan: {
+    cauac: {
+      uk: {
+        title: 'Cauac (Буря)',
+        traits: ['Трансформація','Очищення','Сила'],
+        body: 'Стихія, що змиває старе й народжує новий порядок. У поєднанні з правильним тоном стає опорою під час змін.'
+      },
+      en: {
+        title: 'Cauac (Storm)',
+        traits: ['Transformation','Cleansing','Power'],
+        body: 'A force that washes away the old and brings renewal. With the right tone it stabilizes change.'
+      }
+    }
+  },
+  egypt: {
+    horus: {
+      uk:{title:'Гор (Horus)',traits:['Захист','Справедливість','Лідерство'],body:'Сокіл неба. Бачить широку картину, веде до порядку.'},
+      en:{title:'Horus',traits:['Protection','Justice','Leadership'],body:'Falcon of the sky. Sees the big picture and leads to order.'}
+    }
+  },
+  celtic: {
+    pine: {
+      uk:{title:'Сосна (Pine)',traits:['Витривалість','Гармонія','Спокій'],body:'Витримує бурі й час. Символ внутрішньої сили та рівноваги.'},
+      en:{title:'Pine',traits:['Endurance','Harmony','Calm'],body:'Withstands storms and time. A sign of inner strength and balance.'}
+    }
+  }
+};

--- a/src/data/tone.js
+++ b/src/data/tone.js
@@ -1,0 +1,35 @@
+// Розміщення «тонів» 1..13 у нормалізованій системі (1000x1000).
+// Для спрощення: малюємо на «шапці» гліфа, y = -560..-520
+export function drawMayanTone(ctx, tone){
+  const baseY = -560;
+  const dotR = 24;
+  const gap = 30;
+
+  ctx.save();
+  ctx.lineWidth = 26;
+
+  const drawDot = (x)=>{ ctx.beginPath(); ctx.arc(x, baseY, dotR, 0, Math.PI*2); ctx.stroke(); };
+  const drawBar = (yOffset=0)=>{ ctx.beginPath(); ctx.moveTo(-160, baseY + yOffset); ctx.lineTo(160, baseY + yOffset); ctx.stroke(); };
+
+  // Тони майя: 1..4 точки; 5 — риска; 6..9 — риска + 1..4 точки; 10 — 2 риски; 11..13 — 2 риски + точки
+  if (tone >=1 && tone <=4){
+    const start = -((tone-1)*gap)/2;
+    for(let i=0;i<tone;i++){ drawDot(start + i*gap); }
+  } else if (tone === 5){
+    drawBar(0);
+  } else if (tone >=6 && tone <=9){
+    drawBar(0);
+    const dots = tone-5;
+    const start = -((dots-1)*gap)/2;
+    for(let i=0;i<dots;i++){ drawDot(start + i*gap); }
+  } else if (tone === 10){
+    drawBar(-28); drawBar(28);
+  } else if (tone >=11 && tone <=13){
+    drawBar(-28); drawBar(28);
+    const dots = tone-10;
+    const start = -((dots-1)*gap)/2;
+    for(let i=0;i<dots;i++){ drawDot(start + i*gap); }
+  }
+
+  ctx.restore();
+}

--- a/src/glyphs/celtic/pine.js
+++ b/src/glyphs/celtic/pine.js
@@ -1,0 +1,3 @@
+export default function drawPine(ctx, progress, style){
+  // TODO: додати після MVP (стилізована сосна з вузлами)
+}

--- a/src/glyphs/egypt/horus.js
+++ b/src/glyphs/egypt/horus.js
@@ -1,0 +1,3 @@
+export default function drawHorus(ctx, progress, style){
+  // TODO: додати після MVP (контур сокола з солярним диском)
+}

--- a/src/glyphs/mayan/cauac.js
+++ b/src/glyphs/mayan/cauac.js
@@ -1,0 +1,144 @@
+// Гліф Майя: Cauac (Буря). Нормалізована система 1000x1000, центр (0,0).
+// Малюємо поетапно: 1) картуш, 2) хмарні дуги, 3) блискавка, 4) тон.
+export default function drawCauac(ctx, progress, style, extras){
+  const { stroke = '#cfeef7', glowColor = 'rgba(40,164,201,.35)', lineWidth = 12, shadowBlur = 8 } = style || {};
+  const tone = extras?.tone ?? 5;
+
+  const p1 = Math.min(progress, 0.45) / 0.45;      // картуш
+  const p2 = progress < 0.45 ? 0 : Math.min((progress-0.45)/0.25, 1); // хмари
+  const p3 = progress < 0.70 ? 0 : Math.min((progress-0.70)/0.20, 1); // блискавка
+  const p4 = progress < 0.90 ? 0 : Math.min((progress-0.90)/0.10, 1); // тон
+
+  ctx.save();
+  ctx.lineWidth = lineWidth;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.strokeStyle = stroke;
+  ctx.shadowBlur = shadowBlur;
+  ctx.shadowColor = glowColor;
+
+  // 1) Картуш (округлений прямокутник)
+  if (p1 > 0){
+    roundedPartialRect(ctx, -420, -380, 840, 760, 90, p1);
+  }
+
+  // 2) Хмарні дуги (три сегменти усередині)
+  if (p2 > 0){
+    const cloud = [
+      { cx:-220, cy:-30, r:120, start: Math.PI*1.1, end: Math.PI*1.95 },
+      { cx:   0, cy: -60, r:150, start: Math.PI*1.15, end: Math.PI*1.95 },
+      { cx: 220, cy: -30, r:120, start: Math.PI*1.1, end: Math.PI*1.95 }
+    ];
+    cloud.forEach(({cx,cy,r,start,end})=>{
+      arcPartial(ctx, cx, cy, r, start, end, p2);
+    });
+  }
+
+  // 3) Блискавка (знизу)
+  if (p3 > 0){
+    const zz = [
+      {x:-80, y:120}, {x:-140, y:240}, {x:-40, y:240}, {x:-120, y:360}
+    ];
+    polylinePartial(ctx, zz, p3);
+  }
+
+  // 4) Тон — шапка зверху
+  if (p4 > 0){
+    ctx.globalAlpha = p4;
+    // намалюємо поверх stroke — використається загальний стиль сцени через data/tone.js
+    // тут лише місце-планка (щоб не класти залежність напряму)
+    // (реальний рендер тону робить сцена після виклику цього гліфа)
+  }
+
+  ctx.restore();
+}
+
+// Допоміжні — часткове малювання
+function roundedPartialRect(ctx, x, y, w, h, r, t){
+  // 4 сторони + 4 кути = 8 сегментів. Малюємо від верх-ліво по год.стрілці.
+  const segs = [];
+  const right = x + w, bottom = y + h;
+  // Вершини кутів
+  const TL = {x:x+r, y:y}; const TR={x:right-r, y:y}; const BR={x:right, y:bottom-r}; const BL={x:x+r, y:bottom};
+  // Верхня пряма
+  segs.push({type:'line', from:{x:TL.x, y:TL.y}, to:{x:TR.x, y:TR.y}});
+  // Верхній правий кут
+  segs.push({type:'arc', cx:right-r, cy:y+r, r, start: -Math.PI/2, end: 0});
+  // Права пряма
+  segs.push({type:'line', from:{x:right, y:y+r}, to:{x:right, y:bottom-r}});
+  // Нижній правий кут
+  segs.push({type:'arc', cx:right-r, cy:bottom-r, r, start: 0, end: Math.PI/2});
+  // Нижня пряма
+  segs.push({type:'line', from:{x:TR.x, y:bottom}, to:{x:BL.x, y:bottom}});
+  // Нижній лівий кут
+  segs.push({type:'arc', cx:x+r, cy:bottom-r, r, start: Math.PI/2, end: Math.PI});
+  // Ліва пряма
+  segs.push({type:'line', from:{x:x, y:bottom-r}, to:{x:x, y:y+r}});
+  // Верхній лівий кут
+  segs.push({type:'arc', cx:x+r, cy:y+r, r, start: Math.PI, end: Math.PI*1.5});
+
+  drawSegmentsPartial(ctx, segs, t);
+}
+
+function arcPartial(ctx, cx, cy, r, a0, a1, t){
+  const seg = [{type:'arc', cx, cy, r, start:a0, end:a1}];
+  drawSegmentsPartial(ctx, seg, t);
+}
+
+function polylinePartial(ctx, pts, t){
+  const segs = [];
+  for(let i=0;i<pts.length-1;i++){
+    segs.push({type:'line', from:pts[i], to:pts[i+1]});
+  }
+  drawSegmentsPartial(ctx, segs, t, pts[0]);
+}
+
+function drawSegmentsPartial(ctx, segs, t, moveToFirst){
+  // оцінка загальної довжини
+  const lengths = segs.map(s=> segLength(s));
+  const total = lengths.reduce((a,b)=>a+b,0);
+  const target = total * t;
+  let acc = 0;
+
+  ctx.beginPath();
+  if (moveToFirst){ ctx.moveTo(moveToFirst.x, moveToFirst.y); }
+
+  for(let i=0;i<segs.length;i++){
+    const s = segs[i], L = lengths[i];
+    if (acc + L <= target){
+      drawSeg(ctx, s, 1);
+      acc += L;
+    } else if (acc < target){
+      const remain = target - acc;
+      const frac = Math.max(0, Math.min(1, remain / L));
+      drawSeg(ctx, s, frac);
+      acc = target; break;
+    } else {
+      break;
+    }
+  }
+  ctx.stroke();
+}
+
+function segLength(s){
+  if (s.type==='line'){
+    const dx = s.to.x - s.from.x, dy = s.to.y - s.from.y;
+    return Math.hypot(dx, dy);
+  }
+  if (s.type==='arc'){
+    const sweep = Math.abs(s.end - s.start);
+    return Math.abs(s.r * sweep);
+  }
+  return 0;
+}
+function drawSeg(ctx, s, frac){
+  if (s.type==='line'){
+    const x = s.from.x + (s.to.x - s.from.x)*frac;
+    const y = s.from.y + (s.to.y - s.from.y)*frac;
+    ctx.moveTo(s.from.x, s.from.y);
+    ctx.lineTo(x, y);
+  } else if (s.type==='arc'){
+    const ang = s.start + (s.end - s.start)*frac;
+    ctx.arc(s.cx, s.cy, s.r, s.start, ang, s.end < s.start);
+  }
+}

--- a/src/scenes/SymbolScene.js
+++ b/src/scenes/SymbolScene.js
@@ -1,0 +1,106 @@
+import { getMayanSign, getEgyptSign, getCelticTree, descriptions } from '../data/calendars.js';
+import { drawMayanTone } from '../data/tone.js';
+import drawCauac from '../glyphs/mayan/cauac.js';
+
+const MAYAN_DRAWERS = {
+  cauac: drawCauac
+};
+const STYLE = {
+  stroke: '#cfeef7',
+  glowColor: 'var(--accent-glow)',
+};
+
+export class SymbolScene{
+  constructor(canvas, descNode){
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.descNode = descNode;
+    this.w = 0; this.h = 0;
+    this.progress = 0;
+    this.running = false;
+    this.lang = 'uk';
+    this.active = null; // { calendar: 'mayan'|'egypt'|'celtic', id, extras }
+  }
+
+  setLang(lang){ this.lang = lang || 'uk'; }
+  resize(){
+    const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
+    const rect = this.canvas.getBoundingClientRect();
+    this.w = Math.max(200, Math.floor(rect.width * dpr));
+    this.h = Math.max(200, Math.floor(rect.height * dpr));
+    this.canvas.width = this.w;
+    this.canvas.height = this.h;
+    this.ctx.setTransform(1,0,0,1,0,0);
+    this.ctx.scale(dpr, dpr);
+  }
+
+  start(dateStr){
+    // Для MVP — малюємо тільки Майя (реалізовано Cauac)
+    const mayan = getMayanSign(dateStr);
+    this.active = { calendar:'mayan', id: mayan.signId, extras: { tone: mayan.tone } };
+    this.describe('mayan', mayan.signId);
+
+    this.progress = 0;
+    this.running = true;
+    this._tick();
+  }
+
+  describe(cal, id){
+    const desc = descriptions?.[cal]?.[id]?.[this.lang] || null;
+    if(!desc){ this.descNode.textContent = ''; return; }
+    const traits = (desc.traits||[]).map(t=>`<span class="chip">${t}</span>`).join(' ');
+    this.descNode.innerHTML = `
+      <h3 style="margin:.25rem 0 0.35rem 0">${desc.title}</h3>
+      <p style="margin:.25rem 0 .5rem 0; color:var(--muted)">${traits}</p>
+      <p style="margin:0">${desc.body}</p>
+    `;
+  }
+
+  _tick = () =>{
+    if(!this.running) return;
+    this.progress = Math.min(1, this.progress + 1/60 * 0.8); // ~1.25s
+    this.draw();
+    if(this.progress < 1) requestAnimationFrame(this._tick);
+    else this.running = false;
+  }
+
+  draw(){
+    const ctx = this.ctx;
+    const w = this.canvas.clientWidth;
+    const h = this.canvas.clientHeight;
+
+    ctx.clearRect(0,0,w,h);
+
+    // Нормалізований простір
+    ctx.save();
+    const target = Math.min(w, h) * 0.72;
+    const scale = target / 1000;
+    const lw = Math.max(3, Math.min(10, target*0.012));
+
+    ctx.translate(w/2, h/2);
+    ctx.scale(scale, scale);
+
+    const style = { stroke: getComputedStyle(document.documentElement).getPropertyValue('--fg') || STYLE.stroke,
+                    glowColor: getComputedStyle(document.documentElement).getPropertyValue('--accent-glow') || STYLE.glowColor,
+                    lineWidth: lw, shadowBlur: 8 };
+
+    if(this.active?.calendar === 'mayan'){
+      const fn = MAYAN_DRAWERS[this.active.id] || null;
+      if (fn){
+        ctx.strokeStyle = style.stroke; ctx.lineWidth = style.lineWidth; ctx.shadowBlur = style.shadowBlur; ctx.shadowColor = style.glowColor;
+        fn(ctx, this.progress, style, this.active.extras);
+
+        // Тон — окремим шаром після гліфа, щоб був поверх
+        if (this.progress >= 0.90){
+          ctx.strokeStyle = style.stroke;
+          drawMayanTone(ctx, this.active.extras.tone);
+        }
+      } else {
+        // fallback — рамка
+        ctx.strokeStyle = style.stroke; ctx.lineWidth = lw;
+        ctx.strokeRect(-400, -300, 800, 600);
+      }
+    }
+    ctx.restore();
+  }
+}

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -1,0 +1,25 @@
+.controls{
+  position:sticky; top:0; z-index:10; backdrop-filter: blur(6px);
+  background: linear-gradient(180deg, rgba(11,13,16,.92), rgba(11,13,16,.86));
+  padding:10px 12px; display:grid; align-items:center; gap:12px;
+  grid-template-columns: 1fr auto;
+  border-bottom:1px solid #161b21;
+}
+.controls-left{display:grid; grid-auto-flow:column; gap:12px; align-items:center}
+.controls-right{display:grid; grid-auto-flow:column; gap:10px; align-items:center; justify-self:end}
+
+/* Desktop order: [Дата] [Запустити] …… [Мова | ?] */
+.controls-left .field{min-width:260px}
+
+/* Narrow screens: 2 rows */
+@media (max-width: 600px){
+  .controls{
+    grid-template-columns: 1fr; gap:10px;
+  }
+  .controls-left{grid-template-columns: 1fr auto}
+  .controls-right{
+    grid-template-columns: auto 1fr; /* [?] | [Запустити — довга] */
+    justify-self: stretch;
+  }
+  .btn.primary{width:100%}
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,34 @@
+:root{
+  --bg:#0b0d10;
+  --fg:#eae7de;
+  --muted:#b9b4a6;
+  --accent:#28a4c9; /* майя бірюзово-синій */
+  --accent-glow: rgba(40,164,201,.35);
+  --gap:12px; --pad:12px; --radius:10px;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0; background:var(--bg); color:var(--fg);
+  font:14px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu;
+}
+.btn{cursor:pointer;border:0;border-radius:var(--radius);padding:10px 14px;background:#1b222a;color:var(--fg)}
+.btn.primary{background:var(--accent); color:#061016; font-weight:600}
+.icon-btn{
+  width:42px;height:42px;border-radius:10px;border:1px solid #28313a;background:#14191f;color:var(--fg);
+  display:grid;place-items:center;font-weight:700;cursor:pointer
+}
+.field{display:flex;gap:6px;align-items:center}
+.field .label{color:var(--muted); font-size:12px}
+.field input[type="date"]{
+  appearance:none;background:#14191f;border:1px solid #28313a;color:var(--fg);
+  border-radius:8px;padding:10px 12px;min-height:42px
+}
+.lang-switch{display:inline-grid;grid-auto-flow:column;gap:6px;align-items:center}
+.lang{min-width:48px;min-height:42px;border:1px solid #28313a;background:#14191f;color:var(--fg);border-radius:8px;cursor:pointer}
+.lang[aria-pressed="true"]{background:#223140; border-color:#315066}
+
+.desc{max-width:900px;margin:16px auto;padding:0 16px;color:var(--muted)}
+#stage{position:relative; padding-top:72px /* runtime коригується layout.js */}
+#canvas{display:block;width:100%;height:60vh;max-height:70vh; margin:0 auto; outline:none}
+@media (min-width:1000px){ #canvas{height:70vh} }

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -1,0 +1,33 @@
+export function initControls({ onRun, onLangChange, onHelp }) {
+  const birth = document.getElementById('birthdate');
+  const run   = document.getElementById('runBtn');
+  const help  = document.getElementById('helpBtn');
+  const langBtns = [...document.querySelectorAll('.lang-switch .lang')];
+
+  // Значення за замовчуванням: поточна дата (можна змінити на порожнє при потребі)
+  if(!birth.value){
+    const d = new Date(); const y = d.getFullYear();
+    const m = String(d.getMonth()+1).padStart(2,'0');
+    const day = String(d.getDate()).padStart(2,'0');
+    birth.value = `${y}-${m}-${day}`;
+  }
+
+  // Запуск обчислень за кнопкою
+  run.addEventListener('click', ()=> onRun?.(birth.value));
+  // Просте модальне вікно підказки
+  help.addEventListener('click', ()=> onHelp?.());
+
+  // Перемикання мови — актуалізуємо aria-pressed та викликаємо колбек
+  langBtns.forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      langBtns.forEach(b=>b.setAttribute('aria-pressed','false'));
+      btn.setAttribute('aria-pressed','true');
+      onLangChange?.(btn.dataset.lang);
+    });
+  });
+
+  return {
+    getDate: ()=> birth.value,
+    getLang: ()=> langBtns.find(b=>b.getAttribute('aria-pressed')==='true')?.dataset.lang || 'uk'
+  };
+}

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,0 +1,16 @@
+export function applyStagePadding(){
+  const controls = document.getElementById('controls');
+  const stage = document.getElementById('stage');
+  const h = controls.getBoundingClientRect().height;
+  stage.style.paddingTop = `${Math.ceil(h + 10)}px`;
+}
+
+export function attachLayoutObservers(){
+  applyStagePadding();
+  window.addEventListener('resize', applyStagePadding, { passive:true });
+  // Додатково спостерігаємо за зміненням висоти шапки, якщо це підтримує браузер
+  if('ResizeObserver' in window){
+    const ro = new ResizeObserver(()=> applyStagePadding());
+    ro.observe(document.getElementById('controls'));
+  }
+}


### PR DESCRIPTION
## Summary
- replace the landing markup with a sticky adaptive control bar, canvas stage, and description section
- implement vanilla JS modules for controls, layout, calendar data, and the animated Mayan Cauac glyph scene
- style the new UI with theme variables and responsive control layouts

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d27eddbbdc83208bacb72d01973e66