### PR TITLE
Refine top bar layout and styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -41,134 +41,6 @@ body {
   border: 0;
 }
 
-.top-bar {
-  /* Закріплюємо панель зверху та на всю ширину */
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  min-height: 56px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 0 16px;
-  background: rgba(15, 15, 22, 0.96);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  z-index: 100;
-}
-
-.top-bar__controls {
-  /* Колонка з полем дати, кнопкою запуску та вибором мови */
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  flex: 1 1 auto;
-  min-width: 0;
-  align-items: flex-start;
-}
-
-.controls-row {
-  /* Гнучкий рядок, у якому розташовані основні контролери запуску */
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 8px;
-}
-
-.hint {
-  /* Пояснювальний текст під контролями дати */
-  color: rgba(245, 245, 245, 0.72);
-  font-size: 0.7rem;
-  letter-spacing: 0.02em;
-  display: block;
-}
-
-.top-bar__left {
-  font-size: 0.95rem;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  align-self: flex-start;
-  padding-top: 6px;
-}
-
-.top-bar__toggles {
-  /* Окремий блок для перемикачів сцени та мови */
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-left: auto;
-  align-self: flex-start;
-  padding-top: 6px;
-}
-
-.toggle-group {
-  /* Невеликий контейнер, що групує кнопки перемикача */
-  display: inline-flex;
-  align-items: stretch;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.toggle-button {
-  /* Кнопки перемикачів поводяться як таби */
-  background: transparent;
-  border: none;
-  color: var(--text-main);
-  padding: 6px 12px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.toggle-button:hover {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-.toggle-button.is-active {
-  background: rgba(255, 255, 255, 0.25);
-  color: #050508;
-  font-weight: 600;
-}
-
-#controls-date-row input,
-#controls-date-row select {
-  /* Поля вводу мають простий футуристичний вигляд без зайвих рамок */
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 6px;
-  color: var(--text-main);
-  padding: 6px 10px;
-  font-size: 0.9rem;
-  min-width: 120px;
-}
-
-.info-button {
-  margin-left: 0;
-}
-
-#controls-date-row select {
-  min-width: 100px;
-}
-
-.gender-field {
-  /* Окремий блок для випадаючого списку статі, щоб елементи стояли один під одним */
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-}
-
-.gender-field label {
-  /* Робимо підпис трохи світлішим і компактнішим */
-  color: rgba(245, 245, 245, 0.72);
-  letter-spacing: 0.04em;
-}
-
 .fallback-inputs {
   /* Фолбек-селекти розміщуємо в рядок для економії простору */
   display: flex;
@@ -199,78 +71,6 @@ body {
   padding: 6px 10px;
   font-size: 0.9rem;
   min-width: 72px;
-}
-
-.launch-button,
-.info-button,
-.modal__close {
-  /* Прості кнопки без зайвих ефектів, але з читабельним текстом */
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: var(--text-main);
-  border-radius: 6px;
-  padding: 8px 14px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.launch-button[disabled] {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-.launch-button:not([disabled]):hover,
-.info-button:hover,
-.modal__close:hover {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-.info-button {
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
-  font-weight: 600;
-}
-
-/* Controls row without time input */
-#controls-date-row {
-  display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto 1fr auto auto;
-  gap: 8px;
-  align-items: center;
-  width: 100%;
-}
-
-#controls-date-row .spacer {
-  width: 100%;
-  height: 1px;
-}
-
-/* On small screens stack more compactly */
-@media (max-width: 600px) {
-  #controls-date-row {
-    grid-template-columns: 1fr 1fr auto;
-    grid-template-areas:
-      "date date date"
-      "run lang help";
-  }
-  #dateInput {
-    grid-area: date;
-  }
-  #btnRun {
-    grid-area: run;
-  }
-  #langSelect {
-    grid-area: lang;
-  }
-  #btnHelp {
-    grid-area: help;
-  }
-  #controls-date-row .spacer {
-    display: none;
-  }
 }
 
 #scene {
@@ -327,6 +127,22 @@ body {
   margin-bottom: 16px;
 }
 
+.modal__close {
+  /* Кнопка закриття модалки зберігає простий вигляд */
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text-main);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.modal__close:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 @keyframes overlayFade {
   from {
     opacity: 0;
@@ -347,20 +163,4 @@ body {
   }
 }
 
-@media (max-width: 680px) {
-  .top-bar {
-    gap: 8px;
-    flex-wrap: wrap;
-    height: auto;
-    padding: 12px 16px;
-  }
 
-  #scene {
-    margin-top: 88px;
-  }
-
-  .top-bar__toggles {
-    width: 100%;
-    justify-content: center;
-  }
-}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,7 +26,7 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
     return;
   }
 
-  const topBar = document.querySelector(".top-bar");
+  const topBar = document.querySelector(".topbar");
   const dateInput = document.getElementById("dateInput");
   const genderSelect = document.getElementById("gender");
   const btnRun = document.getElementById("btnRun");
@@ -290,12 +290,10 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
   }
 
   function updateSceneButtons() {
+    // Оновлюємо aria-pressed для кожної кнопки, щоб екранні читачі бачили активний стан.
     sceneButtons.forEach((button) => {
-      if (button.dataset.scene === state.activeSceneKey) {
-        button.classList.add("is-active");
-      } else {
-        button.classList.remove("is-active");
-      }
+      const isActive = button.dataset.scene === state.activeSceneKey;
+      button.setAttribute("aria-pressed", isActive ? "true" : "false");
     });
   }
 
@@ -652,7 +650,8 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
 
   // --- 10. Робота з розмірами канви ---
   function updateCanvasSize() {
-    const headerHeight = topBar.offsetHeight;
+    // Якщо елемент шапки з якоїсь причини не знайдеться, вважаємо її висоту нульовою.
+    const headerHeight = topBar ? topBar.offsetHeight : 0;
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const availableHeight = Math.max(viewportHeight - headerHeight, 200);

--- a/client/assets/css/topbar.css
+++ b/client/assets/css/topbar.css
@@ -1,0 +1,231 @@
+/* ====== Топбар: темна, компактна, рівні поля ====== */
+/* Базові кольори темної теми */
+:root {
+  --bg-900: #0f1115;
+  --bg-850: #151820;
+  --bg-800: #1b1f29;
+  --line-700: #2a2f3a;
+  --txt-100: #e9eef5;
+  --txt-200: #cfd6e4;
+  --accent: #6aa7ff;
+  --accent-press: #4e8cf0;
+  --muted: #97a0b2;
+  --danger: #ff6a7a;
+  --radius: 12px;
+  --h: 44px;        /* Єдина висота елементів */
+  --pad-x: 12px;    /* Горизонтальні відступи інпутів/селектів */
+}
+
+/* Увімкнути темне оформлення для нативних контролів (Chrome/Edge/Firefox) */
+.topbar,
+.topbar select,
+.topbar input {
+  color-scheme: dark;
+}
+
+/* Контейнер топбару */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, var(--bg-900), var(--bg-850));
+  border-bottom: 1px solid var(--line-700);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+/* Зони */
+.topbar__left,
+.topbar__center,
+.topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar__center { justify-content: center; }
+.topbar__right  { justify-content: flex-end; }
+
+/* Поле з міткою зверху */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 240px;
+}
+.field--sm { min-width: 160px; }
+
+.field__label {
+  font-size: 12px;
+  letter-spacing: .02em;
+  color: var(--muted);
+}
+
+/* Уніфікований вигляд інпутів та селектів */
+.field input[type="text"],
+.field input[type="date"],
+.select select {
+  height: var(--h);
+  padding: 0 var(--pad-x);
+  background: var(--bg-800);
+  color: var(--txt-100);
+  border: 1px solid var(--line-700);
+  border-radius: var(--radius);
+  outline: none;
+  transition: border-color .15s ease, background-color .15s ease;
+}
+
+.field input::placeholder { color: #6b7280; }
+
+.field input:focus,
+.select select:focus {
+  border-color: var(--accent);
+  background: #202635;
+}
+
+/* Красива стрілка для select */
+.select {
+  position: relative;
+}
+.select select {
+  appearance: none;        /* прибрати стандартну стрілку */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 36px;     /* місце для стрілки */
+  cursor: pointer;
+}
+.select::after {
+  content: "";
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0; height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 7px solid var(--txt-200); /* стрілка */
+  pointer-events: none;
+  opacity: .9;
+}
+
+/* Кнопки */
+.btn {
+  height: var(--h);
+  padding: 0 18px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line-700);
+  background: var(--bg-800);
+  color: var(--txt-100);
+  font-weight: 600;
+  letter-spacing: .01em;
+  transition: transform .04s ease, background-color .15s ease, border-color .15s ease;
+}
+.btn:hover { background: #232a3a; }
+.btn:active { transform: translateY(1px); }
+.btn--primary {
+  background: var(--accent);
+  color: #0b1020;
+  border-color: transparent;
+}
+.btn--primary:hover { background: var(--accent-press); }
+
+/* Іконкована кнопка (?) */
+.icon-btn {
+  width: var(--h);
+  height: var(--h);
+  display: inline-flex;
+  align-items: center; justify-content: center;
+  border-radius: var(--radius);
+  background: var(--bg-800);
+  color: var(--txt-100);
+  border: 1px solid var(--line-700);
+  font-weight: 700;
+  transition: background-color .15s ease, border-color .15s ease;
+}
+.icon-btn:hover { background: #232a3a; }
+
+/* Сегментований перемикач режимів */
+.segmented {
+  display: inline-flex;
+  background: var(--bg-800);
+  border: 1px solid var(--line-700);
+  border-radius: var(--radius);
+  overflow: hidden;
+  height: var(--h);
+}
+.segmented__btn {
+  padding: 0 14px;
+  color: var(--txt-200);
+  background: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+.segmented__btn + .segmented__btn {
+  border-left: 1px solid var(--line-700);
+}
+.segmented__btn[aria-pressed="true"] {
+  color: var(--txt-100);
+  background: #232a3a;
+}
+
+/* Адаптивність */
+@media (max-width: 1200px) {
+  .topbar { grid-template-columns: 1fr; }
+  .topbar__left, .topbar__center, .topbar__right { justify-content: stretch; flex-wrap: wrap; }
+  .topbar__center { order: 3; }
+  .topbar__right  { order: 2; }
+  .field { flex: 1 1 300px; }
+}
+@media (max-width: 640px) {
+  :root { --h: 40px; }
+  .field { min-width: 100%; }
+  .field--sm { min-width: 48%; }
+}
+
+/* ====== Додаткові уточнення для конкретної верстки ====== */
+/* Пояснювальний текст під датою виглядає як частина поля */
+.field__hint {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+/* Зони ліворуч можуть переносити елементи на новий рядок разом із фолбек-контролями */
+.topbar__left {
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+/* Фолбек із селектами займає всю ширину, щоб ставати рядком під основними полями */
+.topbar__fallback {
+  flex-basis: 100%;
+}
+
+/* Компактніший селект для вибору мови */
+.select--sm select {
+  min-width: 72px;
+}
+
+/* Робимо підписи режимів верхнім регістром для стилістичної єдності */
+.segmented__btn {
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+/* Для дати з типом date приховуємо стандартну піктограму, щоб не зламати візуальний стиль */
+.field input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.8);
+  opacity: 0.8;
+}
+
+/* На невеликих екранах забезпечуємо, щоб фолбек не прилипає до країв */
+@media (max-width: 640px) {
+  .topbar__fallback {
+    flex-basis: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
   <!-- Styles -->
   <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="client/assets/css/topbar.css" />
 
   <!-- Favicon (опційно) -->
   <link rel="icon" href="assets/img/favicon.png" type="image/png" />
@@ -49,14 +50,11 @@
   gtag('config', 'G-R03TE5MZQ7');
 </script>
   <body>
-    <!-- Верхня панель керування, що залишається на місці під час прокрутки -->
-    <header class="top-bar">
-      <div class="top-bar__left" data-i18n="topBarLabel">Твоя дата народження</div>
-
-      <div class="top-bar__controls" id="native-date-controls">
-        <!-- DATE ROW (no time) -->
-        <div class="controls-row" id="controls-date-row" aria-label="Date controls">
-          <label for="dateInput" class="visually-hidden" data-i18n="date_label">Дата</label>
+    <!-- Вирівняна верхня панель із керуванням датою, режимами та мовою -->
+    <header class="topbar" role="banner" aria-label="Основна панель керування">
+      <div class="topbar__left">
+        <label class="field" for="dateInput">
+          <span class="field__label" data-i18n="topBarLabel">Твоя дата народження</span>
           <input
             id="dateInput"
             type="date"
@@ -65,62 +63,62 @@
             aria-describedby="dateHelp"
             required
           />
+          <small id="dateHelp" class="field__hint" data-i18n="date_help">
+            Обери дату народження (без часу).
+          </small>
+        </label>
 
-          <div class="gender-field">
-            <label for="gender" data-i18n="gender_label">Стать</label>
-            <select id="gender" name="gender">
+        <label class="field field--sm" for="gender">
+          <span class="field__label" data-i18n="gender_label">Стать</span>
+          <div class="select">
+            <select id="gender" name="gender" aria-label="Стать">
               <option value="unspecified" selected data-i18n="gender_unspecified">Не вказувати</option>
               <option value="female" data-i18n="gender_female">Жіноча</option>
               <option value="male" data-i18n="gender_male">Чоловіча</option>
             </select>
           </div>
+        </label>
 
-          <button id="btnRun" class="launch-button" type="button" data-i18n="run_btn" disabled>
-            Запустити
-          </button>
-
-          <div class="spacer" aria-hidden="true"></div>
-
-          <label for="langSelect" class="visually-hidden" data-i18n="lang_label">Мова</label>
-          <select id="langSelect" aria-label="Language" data-i18n-attr="aria-label" data-i18n="lang_label">
-            <option value="ua">UA</option>
-            <option value="en">EN</option>
-          </select>
-
-          <button
-            id="btnHelp"
-            type="button"
-            class="info-button"
-            aria-haspopup="dialog"
-            aria-controls="info-modal"
-            data-i18n-attr="aria-label"
-            data-i18n="infoAriaLabel"
-          >
-            ?
-          </button>
-        </div>
-        <small id="dateHelp" class="hint" data-i18n="date_help">
-          Обери дату народження (без часу).
-        </small>
-        <div class="fallback-inputs" id="fallback-inputs" hidden>
-          <div class="fallback-group">
-            <label for="daySelect" data-i18n="fallbackDayLabel">День</label>
-            <select id="daySelect"></select>
-          </div>
-          <div class="fallback-group">
-            <label for="monthSelect" data-i18n="fallbackMonthLabel">Місяць</label>
-            <select id="monthSelect"></select>
-          </div>
-          <div class="fallback-group">
-            <label for="yearSelect" data-i18n="fallbackYearLabel">Рік</label>
-            <select id="yearSelect"></select>
+        <div class="topbar__fallback" id="native-date-controls">
+          <div class="fallback-inputs" id="fallback-inputs" hidden>
+            <div class="fallback-group">
+              <label for="daySelect" data-i18n="fallbackDayLabel">День</label>
+              <select id="daySelect"></select>
+            </div>
+            <div class="fallback-group">
+              <label for="monthSelect" data-i18n="fallbackMonthLabel">Місяць</label>
+              <select id="monthSelect"></select>
+            </div>
+            <div class="fallback-group">
+              <label for="yearSelect" data-i18n="fallbackYearLabel">Рік</label>
+              <select id="yearSelect"></select>
+            </div>
           </div>
         </div>
       </div>
 
-      <div class="top-bar__toggles">
+      <div class="topbar__center">
+        <button id="btnRun" class="btn btn--primary" type="button" data-i18n="run_btn" disabled>
+          Запустити
+        </button>
+      </div>
+
+      <div class="topbar__right">
+        <label for="langSelect" class="visually-hidden" data-i18n="lang_label">Мова</label>
+        <div class="select select--sm" aria-label="Мова інтерфейсу">
+          <select
+            id="langSelect"
+            aria-label="Language"
+            data-i18n-attr="aria-label"
+            data-i18n="lang_label"
+          >
+            <option value="ua">UA</option>
+            <option value="en">EN</option>
+          </select>
+        </div>
+
         <div
-          class="toggle-group"
+          class="segmented"
           id="scene-toggle"
           role="group"
           data-i18n-attr="aria-label"
@@ -128,21 +126,35 @@
         >
           <button
             type="button"
-            class="toggle-button"
+            class="segmented__btn"
             data-scene="lissajous"
+            aria-pressed="false"
             data-i18n="sceneLissajous"
           >
             Ліссажу
           </button>
           <button
             type="button"
-            class="toggle-button"
+            class="segmented__btn"
             data-scene="rune"
+            aria-pressed="false"
             data-i18n="sceneRune"
           >
             Руни
           </button>
         </div>
+
+        <button
+          id="btnHelp"
+          type="button"
+          class="icon-btn"
+          aria-haspopup="dialog"
+          aria-controls="info-modal"
+          data-i18n-attr="aria-label"
+          data-i18n="infoAriaLabel"
+        >
+          ?
+        </button>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- reorganized the header controls into a semantic sticky top bar with balanced left/center/right sections and updated markup for accessibility
- introduced a dedicated dark top bar stylesheet and removed the legacy top-bar rules from the base styles
- synced scene toggle aria-pressed states in JavaScript and guarded against missing header heights when resizing the canvas

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2db66cdfc83208e680d84ae9206fb