### PR TITLE
Allow mobile scrolling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -185,6 +185,12 @@ body {
 }
 
 @media (max-width: 767px) {
+  body {
+    /* На мобільних дозволяємо вертикальну прокрутку, щоб користувач міг дістатися всіх блоків */
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch; /* Плавне прокручування на пристроях iOS */
+  }
+
   .header {
     padding: 16px 12px;
   }


### PR DESCRIPTION
## Summary
- allow the main page to scroll vertically on narrow screens by overriding the body overflow setting
- improve iOS ergonomics by enabling touch-friendly momentum scrolling

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d4fc2fbb848320819175d7b37efe3e