### PR TITLE
Add expandable canvas view toggle

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -133,6 +133,82 @@ body {
   width: 100%;
 }
 
+.canvas-container--expanded {
+  /* У розгорнутому режимі фіксуємо контейнер всередині вікна з невеликими полями */
+  position: fixed;
+  inset: 5vh 5vw;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  z-index: 160;
+  padding: 16px;
+  background: rgba(3, 7, 18, 0.92);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.canvas-toggle {
+  /* Кнопка керування режимом канви закріплена у правому верхньому куті контейнера */
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 18, 32, 0.72);
+  color: var(--text-main);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+  z-index: 2;
+}
+
+.canvas-toggle:hover,
+.canvas-toggle:focus {
+  /* Надаємо легке підсвічення при наведенні або фокусі */
+  background: rgba(37, 99, 235, 0.8);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.canvas-toggle__icon {
+  /* Невеликий відступ навколо SVG-іконки для кращої читабельності */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+}
+
+.canvas-container--expanded .canvas-toggle {
+  /* Під час розгортання переміщуємо кнопку ближче до краю діалогу */
+  top: 12px;
+  right: 12px;
+}
+
+.canvas-overlay {
+  /* Півпрозорий фон, що акцентує увагу на розгорнутій канві */
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+  z-index: 150;
+}
+
+.canvas-overlay.is-active {
+  opacity: 1;
+  pointer-events: all;
+}
+
 .canvas-placeholder {
   /* Пояснювальний текст відображається, поки не запущено генерацію */
   position: absolute;

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -47,6 +47,8 @@ const I18N = {
     sceneToggleAria: "Вибір сцени",
     footerDescription: "Поєднання стародавніх календарів із сучасною графікою",
     placeholderText: "Введи дату народження, щоб побачити свою унікальну ауру",
+    canvasExpand: "Розгорнути",
+    canvasCollapse: "Згорнути",
   },
   en: {
     title: "Aura — generative graphics",
@@ -91,6 +93,8 @@ const I18N = {
     sceneToggleAria: "Scene selection",
     footerDescription: "Combining ancient calendars with modern graphics",
     placeholderText: "Enter your birth date to generate your unique aura pattern",
+    canvasExpand: "Expand",
+    canvasCollapse: "Collapse",
   },
 };
 

--- a/index.html
+++ b/index.html
@@ -196,7 +196,25 @@
           <div class="canvas-placeholder" id="canvas-placeholder" data-i18n="placeholderText">
             Enter your birth date to generate your unique aura pattern
           </div>
+          <button
+            class="canvas-toggle"
+            id="canvas-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="scene"
+          >
+            <span class="canvas-toggle__icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="9 3 3 3 3 9"></polyline>
+                <polyline points="15 21 21 21 21 15"></polyline>
+                <line x1="3" y1="3" x2="10" y2="10"></line>
+                <line x1="21" y1="21" x2="14" y2="14"></line>
+              </svg>
+            </span>
+            <span class="canvas-toggle__label" id="canvas-toggle-label">Expand</span>
+          </button>
         </div>
+        <div class="canvas-overlay" id="canvas-overlay" hidden aria-hidden="true"></div>
       </main>
 
       <footer class="footer">


### PR DESCRIPTION
## Summary
- add an overlay toggle button to expand and collapse the canvas without interrupting rendering
- style the expanded view and dimmed overlay for focus and accessibility
- extend i18n resources and logic to localize the new control

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5368a0f488320bbc295f43f0b9936