### PR TITLE
Refine Maya scene rendering

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,7 +20,8 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
 
   // --- 1. Збір посилань на DOM-елементи ---
   const canvas = document.getElementById("scene");
-  const ctx = canvas.getContext("2d");
+  // Просимо контекст одразу з підтримкою прозорості, аби фон задавався лише через CSS.
+  const ctx = canvas.getContext("2d", { alpha: true });
   if (!ctx) {
     console.error("Canvas 2D не підтримується в цьому браузері.");
     return;
@@ -692,8 +693,9 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
     state.lastFrameTime = now - (elapsed % frameInterval);
 
     ctx.setTransform(state.effectiveDpr, 0, 0, state.effectiveDpr, 0, 0);
-    ctx.fillStyle = CONFIG.global.CANVAS_BG;
-    ctx.fillRect(0, 0, state.cssWidth, state.cssHeight);
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+    ctx.clearRect(0, 0, state.cssWidth, state.cssHeight);
 
     ctx.save();
     ctx.setTransform(

--- a/assets/js/utils/tzolkin-number.js
+++ b/assets/js/utils/tzolkin-number.js
@@ -5,77 +5,154 @@
    * Малюємо число 1..13 у вигляді традиційних майянських позначок.
    * @param {CanvasRenderingContext2D} ctx - контекст цільового canvas.
    * @param {number} tone - число від 1 до 13.
-   * @param {number} x - координата лівого верхнього кута області відрисовки.
-   * @param {number} y - координата лівого верхнього кута області відрисовки.
-   * @param {number} width - доступна ширина.
-   * @param {object} [options] - додаткові налаштування стилю.
+   * @param {{x:number, y:number, w:number, h:number}} toneBox - прямокутник розміщення у дизайн-координатах.
+   * @param {object} [options] - додаткові налаштування стилю (кольори та коефіцієнти масштабу).
    * @returns {number} - фактична висота намальованої композиції (щоб сцені легше було центрувати).
    */
-  function drawTzolkinNumber(ctx, tone, x, y, width, options = {}) {
+  const BASE_SIZE = 40;
+  const DOT_SLOTS = {
+    0: [],
+    1: [20],
+    2: [16, 24],
+    3: [12, 20, 28],
+    4: [8, 16, 24, 32],
+  };
+  const DOT_Y = 14;
+  const BASE_DOT_RADIUS = 3.5;
+  const BASE_LINE_WIDTH = 4;
+  const BAR_BASE = { top: 24.5, bottom: 26.5 };
+  const BAR_GEOMETRY = [
+    { offset: 0 },
+    { offset: 6 },
+  ];
+
+  /**
+   * Обчислюємо межі композиції у нормалізованій системі координат (0..40).
+   * Це потрібно, щоб правильно центрувати число у прямокутнику toneBox.
+   */
+  function computeNormalizedBounds(barsCount, dotsCount, lineWidthBase, dotRadiusBase) {
+    let minY = Infinity;
+    let maxY = -Infinity;
+
+    if (dotsCount > 0) {
+      minY = Math.min(minY, DOT_Y - dotRadiusBase);
+      maxY = Math.max(maxY, DOT_Y + dotRadiusBase);
+    }
+
+    for (let i = 0; i < Math.min(barsCount, BAR_GEOMETRY.length); i += 1) {
+      const bar = BAR_GEOMETRY[i];
+      minY = Math.min(minY, BAR_BASE.top + bar.offset - lineWidthBase / 2);
+      maxY = Math.max(maxY, BAR_BASE.bottom + bar.offset + lineWidthBase / 2);
+    }
+
+    if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+      // На випадок непередбаченої ситуації повертаємо межі крапок.
+      minY = DOT_Y - dotRadiusBase;
+      maxY = DOT_Y + dotRadiusBase;
+    }
+
+    return { min: minY, max: maxY };
+  }
+
+  /**
+   * Малюємо окрему риску (бар) за заданим зміщенням.
+   */
+  function renderBar(ctx, mapX, mapY, offset) {
+    ctx.beginPath();
+    ctx.moveTo(mapX(8), mapY(26 + offset));
+    ctx.quadraticCurveTo(mapX(14), mapY(24.5 + offset), mapX(20), mapY(25.5 + offset));
+    ctx.quadraticCurveTo(mapX(26), mapY(26.5 + offset), mapX(32), mapY(25 + offset));
+    ctx.stroke();
+  }
+
+  /**
+   * Малюємо набір крапок залежно від кількості.
+   */
+  function renderDots(ctx, mapX, mapY, dotsCount, radius) {
+    const slots = DOT_SLOTS[dotsCount] || DOT_SLOTS[0];
+    const cy = mapY(DOT_Y);
+    for (let i = 0; i < slots.length; i += 1) {
+      const cx = mapX(slots[i]);
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function drawTzolkinNumber(ctx, tone, toneBox, options = {}) {
     if (!ctx) {
       throw new Error("drawTzolkinNumber очікує коректний 2D-контекст");
     }
     if (typeof tone !== "number" || tone < 1 || tone > 13) {
       throw new Error("drawTzolkinNumber працює лише з тоном у діапазоні 1..13");
     }
+    if (!toneBox || typeof toneBox !== "object") {
+      throw new Error("drawTzolkinNumber очікує об'єкт toneBox з координатами x, y, w, h");
+    }
 
-    // Акуратно дістаємо кольори та розміри з опцій (або задаємо вдалі значення за замовчуванням).
-    const strokeColor = options.strokeColor || "#f6f1e6";
+    const x = Number(toneBox.x) || 0;
+    const y = Number(toneBox.y) || 0;
+    const w = Number(toneBox.w) || 0;
+    const h = Number(toneBox.h) || 0;
+    if (w <= 0 || h <= 0) {
+      return 0;
+    }
+
+    // Розкладаємо число на риски (кожна дорівнює п'ятірці) та крапки (решта від ділення).
+    const barsCount = Math.floor(tone / 5);
+    const dotsCount = tone % 5;
+
+    const lineWidthFactor = typeof options.lineWidthFactor === "number" && options.lineWidthFactor > 0 ? options.lineWidthFactor : 1;
+    const dotRadiusFactor = typeof options.dotRadiusFactor === "number" && options.dotRadiusFactor > 0 ? options.dotRadiusFactor : 1;
+
+    const lineWidthBase = BASE_LINE_WIDTH * lineWidthFactor;
+    const dotRadiusBase = BASE_DOT_RADIUS * dotRadiusFactor;
+
+    const bounds = computeNormalizedBounds(barsCount, dotsCount, lineWidthBase, dotRadiusBase);
+    const usedHeight = bounds.max - bounds.min;
+
+    let scale = w / BASE_SIZE;
+    if (usedHeight > 0) {
+      scale = Math.min(scale, h / usedHeight);
+    } else {
+      scale = Math.min(scale, h / BASE_SIZE);
+    }
+    if (!Number.isFinite(scale) || scale <= 0) {
+      return 0;
+    }
+
+    const horizontalOffset = x + (w - BASE_SIZE * scale) / 2;
+    const verticalOffset = y + (h - usedHeight * scale) / 2 - bounds.min * scale;
+
+    const mapX = (nx) => horizontalOffset + nx * scale;
+    const mapY = (ny) => verticalOffset + ny * scale;
+
+    const strokeColor = options.strokeColor || "#f6eddc";
     const accentColor = options.accentColor || strokeColor;
-    const lineWidth = options.lineWidth || width * 0.08;
-    const dotRadius = options.dotRadius || width * 0.1;
-    const spacing = options.spacing || width * 0.12;
-    const barLength = options.barLength || width * 0.82;
+    const lineWidth = lineWidthBase * scale;
+    const dotRadius = dotRadiusBase * scale;
 
     ctx.save();
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
     ctx.strokeStyle = strokeColor;
     ctx.fillStyle = accentColor;
+    ctx.lineWidth = lineWidth;
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
 
-    // Розкладаємо число на кількість рисок (кожна означає 5) та крапок (1..4).
-    const barsCount = Math.floor(tone / 5);
-    const dotsCount = tone % 5;
-
-    const barsHeight = barsCount > 0 ? barsCount * lineWidth + (barsCount - 1) * spacing : 0;
-    const dotsHeight = dotsCount > 0 ? dotRadius * 2 : 0;
-    const gapBetweenGroups = barsCount > 0 && dotsCount > 0 ? spacing : 0;
-    const totalHeight = barsHeight + dotsHeight + gapBetweenGroups;
-
-    let cursorY = y;
-
-    // Спершу малюємо крапки (вони завжди розташовані над рисками).
     if (dotsCount > 0) {
-      const dotSpacing = options.dotSpacing || dotRadius * 2.1;
-      const totalDotsWidth = dotsCount === 1 ? dotRadius * 2 : dotRadius * 2 + dotSpacing * (dotsCount - 1);
-      const startX = x + (width - totalDotsWidth) / 2;
-      const centerY = cursorY + dotRadius;
-
-      for (let i = 0; i < dotsCount; i += 1) {
-        const cx = startX + i * dotSpacing;
-        ctx.beginPath();
-        ctx.arc(cx + dotRadius, centerY, dotRadius, 0, Math.PI * 2);
-        ctx.fill();
-      }
-
-      cursorY += dotsHeight + gapBetweenGroups;
+      renderDots(ctx, mapX, mapY, dotsCount, dotRadius);
     }
 
-    // Тепер малюємо риски — горизонтальні смуги з закругленими краями.
-    if (barsCount > 0) {
-      const barStartX = x + (width - barLength) / 2;
-      for (let i = 0; i < barsCount; i += 1) {
-        const barY = cursorY + i * (lineWidth + spacing) + lineWidth / 2;
-        ctx.beginPath();
-        ctx.moveTo(barStartX, barY);
-        ctx.lineTo(barStartX + barLength, barY);
-        ctx.lineWidth = lineWidth;
-        ctx.stroke();
-      }
+    for (let i = 0; i < Math.min(barsCount, BAR_GEOMETRY.length); i += 1) {
+      const bar = BAR_GEOMETRY[i];
+      renderBar(ctx, mapX, mapY, bar.offset);
     }
 
     ctx.restore();
-    return totalHeight;
+
+    return usedHeight * scale;
   }
 
   window.drawTzolkinNumber = drawTzolkinNumber;


### PR DESCRIPTION
## Summary
- request a transparent 2D canvas context and clear the frame before each draw call
- drop the debug backdrop in the Maya scene and render the tone glyph only after the outline animation finishes
- rebuild the Tzolkin number renderer with scaled Maya-style curves and dot placement mapped to the tone box

## Testing
- Manual verification with Playwright screenshot of the Maya scene

------
https://chatgpt.com/codex/tasks/task_e_68d8454fa64c8320a03a5351ad33ba90