### PR TITLE
Implement gender theme switching without restarting animations

### DIFF
--- a/assets/js/scenes/scene-maya.js
+++ b/assets/js/scenes/scene-maya.js
@@ -387,6 +387,43 @@
     }
 
     /**
+     * Акуратно оновлюємо тему кольорів без перезапуску таймлайну анімації.
+     */
+    updateTheme({ gender } = {}) {
+      const nextGender = gender === "male" || gender === "female" ? gender : "unspecified";
+      if (nextGender === this.gender && this.palette) {
+        return;
+      }
+      this.gender = nextGender;
+      this.palette = this.pickPalette(this.gender);
+
+      const recolorSegment = (segment) => {
+        if (!segment || typeof segment !== "object") {
+          return;
+        }
+        if (segment.groupName === "outline") {
+          segment.color = this.palette.outline;
+        } else if (segment.groupName === "details") {
+          segment.color = this.palette.details;
+        } else if (segment.groupName === "fills") {
+          segment.color = this.palette.fills;
+        }
+      };
+
+      if (this.animation && Array.isArray(this.animation.segments)) {
+        this.animation.segments.forEach(recolorSegment);
+      }
+
+      if (Array.isArray(this.cachedSegments) && this.cachedSegments !== this.animation.segments) {
+        this.cachedSegments.forEach(recolorSegment);
+      }
+
+      if (this.animation && typeof this.animation === "object") {
+        this.animation.easing = this.palette.easing || this.animation.easing;
+      }
+    }
+
+    /**
      * Основний метод ініціалізації сцени: готуємо дату, палітру та завантажуємо SVG.
      */
     init(seedStr, prng, context = {}) {
@@ -593,6 +630,7 @@
             kind: group.kind,
             color: group.color,
             widthFactor: group.widthFactor,
+            groupName: group.name,
           });
           if (!this.shouldReduceMotion) {
             currentTime += duration;

--- a/client/assets/css/theme.css
+++ b/client/assets/css/theme.css
@@ -1,0 +1,62 @@
+/*
+  Тематичні змінні для гліфа AURA.
+  Коментарі детально описують логіку українською мовою, аби навіть новачок розібрався.
+*/
+
+#aura {
+  /* Базові значення, що працюють як нейтральна тема до визначення статі користувачем */
+  --aura-bg: #0b0d10;
+  --aura-glyph-stroke: #79a8ff;
+  --aura-glyph-fill: transparent;
+  --aura-digit-color: #eaeef7;
+  --aura-accent: #79a8ff;
+}
+
+/* Чоловіча тема: холодні блакитні відтінки */
+#aura[data-gender="male"] {
+  --aura-glyph-stroke: #7aa6ff;
+  --aura-accent: #7aa6ff;
+  --aura-digit-color: #dfe9ff;
+}
+
+/* Жіноча тема: теплі рожеві тони */
+#aura[data-gender="female"] {
+  --aura-glyph-stroke: #ff7ad1;
+  --aura-accent: #ff7ad1;
+  --aura-digit-color: #ffe5f4;
+}
+
+/* Нейтральний режим (коли стать не вказана) злегка відрізняється від базового */
+#aura[data-gender="unspecified"] {
+  --aura-glyph-stroke: #9ac8ff;
+  --aura-accent: #9ac8ff;
+  --aura-digit-color: #f5f7ff;
+}
+
+/* Прив'язуємо колірні змінні до SVG-класів, якщо такі присутні в розмітці */
+#aura svg .stroke {
+  stroke: var(--aura-glyph-stroke);
+  transition: stroke 0.25s ease;
+}
+
+#aura svg .fill {
+  fill: var(--aura-glyph-fill);
+  transition: fill 0.25s ease;
+}
+
+/* Цифра над гліфом може бути реалізована як DOM-елемент із класом digit */
+#aura .digit {
+  color: var(--aura-digit-color);
+  transition: color 0.25s ease;
+}
+
+/* Допоміжний акцент для елементів інтерфейсу, що залежать від теми */
+#aura [data-accent="border"] {
+  border-color: var(--aura-accent);
+  transition: border-color 0.25s ease;
+}
+
+#aura [data-accent="color"] {
+  color: var(--aura-accent);
+  transition: color 0.25s ease;
+}

--- a/client/assets/js/genderToggle.js
+++ b/client/assets/js/genderToggle.js
@@ -1,0 +1,79 @@
+/**
+ * Простий модуль для керування темою статі.
+ * Весь код детально прокоментовано українською мовою, щоб його легко було підтримувати навіть новачкам.
+ */
+
+const GENDER_STORAGE_KEY = "aura.gender";
+const VALID_GENDERS = ["male", "female", "unspecified"];
+
+/**
+ * Перевіряємо, чи значення належить до дозволеного списку, інакше повертаємо "unspecified".
+ */
+function normalizeGender(value) {
+  return VALID_GENDERS.includes(value) ? value : "unspecified";
+}
+
+/**
+ * Обережно читаємо збережене значення з localStorage.
+ */
+export function readStoredGender() {
+  try {
+    const stored = window.localStorage.getItem(GENDER_STORAGE_KEY);
+    return stored ? normalizeGender(stored) : null;
+  } catch (error) {
+    // Якщо браузер блокує доступ до localStorage (наприклад, приватний режим) — повертаємо null.
+    return null;
+  }
+}
+
+/**
+ * Зберігаємо поточний вибір статі у localStorage.
+ */
+function persistGender(value) {
+  try {
+    window.localStorage.setItem(GENDER_STORAGE_KEY, normalizeGender(value));
+  } catch (error) {
+    // Мовчазно ігноруємо помилки, щоб не зупиняти роботу застосунку.
+  }
+}
+
+/**
+ * Повертаємо кореневий контейнер гліфа AURA.
+ */
+function getAuraRoot() {
+  return document.getElementById("aura");
+}
+
+/**
+ * Ініціалізуємо тему: беремо збережене значення або застосовуємо передане за замовчуванням.
+ * @param {string} defaultGender - значення, яке використовуємо, якщо сховище порожнє або недоступне.
+ * @returns {string} - підсумкове значення, яке застосували.
+ */
+export function initGenderTheme(defaultGender = "unspecified") {
+  const root = getAuraRoot();
+  const stored = readStoredGender();
+  const normalizedDefault = normalizeGender(defaultGender);
+  const applied = stored ?? normalizedDefault;
+  if (root) {
+    root.setAttribute("data-gender", applied);
+  }
+  if (!stored) {
+    persistGender(applied);
+  }
+  return applied;
+}
+
+/**
+ * Оновлюємо тему, записуючи її у data-атрибут і localStorage.
+ * @param {string} gender - нове значення (male/female/unspecified).
+ * @returns {string} - нормалізоване значення, яке було застосовано.
+ */
+export function setGenderTheme(gender) {
+  const root = getAuraRoot();
+  const normalized = normalizeGender(gender);
+  if (root) {
+    root.setAttribute("data-gender", normalized);
+  }
+  persistGender(normalized);
+  return normalized;
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="stylesheet" href="client/assets/css/theme.css" />
     <link rel="stylesheet" href="client/assets/css/topbar.css" />
 
     <!-- Favicon (опційно) -->
@@ -52,7 +53,8 @@
     gtag("config", "G-R03TE5MZQ7");
   </script>
   <body>
-    <div class="app">
+    <div id="aura" data-gender="unspecified">
+      <div class="app">
       <header class="header">
         <h1 class="title">AURA</h1>
         <p class="subtitle" id="subtitle" data-i18n="subtitle">
@@ -225,27 +227,29 @@
           </span>
         </p>
       </footer>
+      </div>
     </div>
 
-    <!-- Модальне вікно з поясненням задуму сайту -->
-    <div
-      class="modal"
-      id="info-modal"
-      hidden
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="info-modal-title"
-    >
-      <div class="modal__overlay" id="modal-overlay"></div>
-      <div class="modal__dialog">
-        <div class="modal__content">
-          <h2 class="modal__title" id="info-modal-title" data-i18n="aboutTitle">Про проєкт</h2>
-          <p class="modal__text" data-i18n-html="modalText">
-            Цей сайт відкриває приховану геометрію вашого життя.<br />
-            На основі дати народження народжується унікальний візерунок — візуальний відбиток вашої присутності у Всесвіті.<br />
-            Це не просто анімація, а символ початку й таємниці, який завжди буде лише вашим.
-          </p>
-          <button class="modal__close" id="modal-close" data-i18n="modalClose">Добре</button>
+      <!-- Модальне вікно з поясненням задуму сайту -->
+      <div
+        class="modal"
+        id="info-modal"
+        hidden
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="info-modal-title"
+      >
+        <div class="modal__overlay" id="modal-overlay"></div>
+        <div class="modal__dialog">
+          <div class="modal__content">
+            <h2 class="modal__title" id="info-modal-title" data-i18n="aboutTitle">Про проєкт</h2>
+            <p class="modal__text" data-i18n-html="modalText">
+              Цей сайт відкриває приховану геометрію вашого життя.<br />
+              На основі дати народження народжується унікальний візерунок — візуальний відбиток вашої присутності у Всесвіті.<br />
+              Це не просто анімація, а символ початку й таємниці, який завжди буде лише вашим.
+            </p>
+            <button class="modal__close" id="modal-close" data-i18n="modalClose">Добре</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap the app markup in the `#aura` container and load dedicated CSS variables for gender-dependent colors
- add a small helper module that keeps `data-gender` and localStorage in sync with the selector value
- update the Maya scene so it recolors existing animation segments when the gender changes instead of restarting the timeline

## Testing
- not run (no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68d84f8810308320829313600d2c938b