### PR TITLE
Ensure aura description stays visible across breakpoints

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,6 +46,8 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
   const canvasToggle = document.getElementById("canvas-toggle");
   const canvasToggleLabel = document.getElementById("canvas-toggle-label");
   const canvasOverlay = document.getElementById("canvas-overlay");
+  // Зберігаємо посилання на секцію з канвою, щоб точніше вимірювати доступну ширину в макеті.
+  const auraVisualSection = document.getElementById("aura-visual");
 
   const descRoot = document.getElementById("aura-desc");
   const descSummary = descRoot?.querySelector('[data-role="desc-summary"]');
@@ -1137,17 +1139,39 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
       const footerHeight = footer ? footer.offsetHeight : 0;
       availableHeight = Math.max(viewportHeight - headerHeight - footerHeight, 200);
 
-      // Вираховуємо доступну ширину з урахуванням горизонтальних відступів секції з канвою.
-      if (patternArea) {
+      // Вимірюємо ширину колонки з канвою, щоб опис завжди мав власне місце праворуч.
+      let measuredWidth = 0;
+      if (canvasWrapper) {
+        const previousInlineWidth = canvasWrapper.style.width;
+        canvasWrapper.style.width = "";
+        const visualContainer = auraVisualSection || canvasWrapper.parentElement;
+        if (visualContainer) {
+          measuredWidth = visualContainer.clientWidth;
+        }
+        if (!measuredWidth && patternArea) {
+          measuredWidth = patternArea.clientWidth;
+        }
+        canvasWrapper.style.width = previousInlineWidth;
+      } else if (patternArea) {
+        measuredWidth = patternArea.clientWidth;
+      }
+
+      if (!measuredWidth && patternArea) {
         const computed = window.getComputedStyle(patternArea);
         const paddingX = parseFloat(computed.paddingLeft || "0") + parseFloat(computed.paddingRight || "0");
-        containerWidth = Math.max(viewportWidth - paddingX, 320);
+        measuredWidth = viewportWidth - paddingX;
       }
+
+      containerWidth = Math.max(measuredWidth || 0, 320);
     }
 
     if (canvasWrapper) {
       canvasWrapper.style.height = `${availableHeight}px`;
-      canvasWrapper.style.width = `${containerWidth}px`;
+      if (state.isCanvasExpanded) {
+        canvasWrapper.style.width = `${containerWidth}px`;
+      } else {
+        canvasWrapper.style.width = "100%";
+      }
     }
 
     const effectiveDpr = Math.min(window.devicePixelRatio || 1, CONFIG.global.MAX_DEVICE_PIXEL_RATIO);

--- a/client/assets/css/desc.css
+++ b/client/assets/css/desc.css
@@ -28,9 +28,10 @@
 }
 
 /*
-  Головний контейнер для канви і опису. На десктопі показуємо їх поруч, а на мобільних — стовпчиком.
+  Головний контейнер із канвою та текстом. За замовчуванням елементи складаються вертикально,
+  щоб опис з'являвся під гліфом на мобільних.
 */
-.pattern-layout {
+#aura-page {
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -38,13 +39,32 @@
   max-width: 1280px;
 }
 
+/*
+  Блок із візуалізацією тримаємо як окрему секцію, щоб у гріді він займав ліву колонку.
+  min-width: 0 дозволяє канві стискатися, не виштовхуючи опис за межі екрана.
+*/
+#aura-visual {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  min-width: 0;
+}
+
 @media (min-width: 1024px) {
-  .pattern-layout {
-    flex-direction: row;
-    align-items: stretch;
+  /*
+    На широких екранах вмикаємо дві колонки: канва зліва, текст праворуч.
+    Grid дозволяє краще контролювати ширину правої панелі та проміжок між блоками.
+  */
+  #aura-page {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 420px;
+    gap: 24px;
+    align-items: start;
   }
-  .pattern-layout .canvas-container {
-    flex: 1 1 auto;
+
+  #aura-visual {
+    grid-column: 1;
   }
 }
 
@@ -59,18 +79,19 @@
   color: var(--aura-desc-text);
   backdrop-filter: blur(18px);
   box-shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
-  max-height: 80vh;
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
   width: 100%;
 }
 
 @media (min-width: 1024px) {
   #aura-desc {
-    flex: 0 0 380px;
-    max-width: 420px;
+    grid-column: 2;
     position: sticky;
     top: 32px;
-    align-self: flex-start;
+    max-width: 420px;
+    max-height: calc(100dvh - 64px);
+    overflow-y: auto;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -195,39 +195,41 @@
       </nav>
 
       <main class="pattern-area">
-        <div class="pattern-layout">
-          <div class="canvas-container" id="canvas-wrapper">
-            <canvas id="scene" aria-hidden="true"></canvas>
-            <div class="canvas-placeholder" id="canvas-placeholder" data-i18n="placeholderText">
-              Enter your birth date to generate your unique aura pattern
+        <div id="aura-page" class="pattern-layout">
+          <section id="aura-visual">
+            <div class="canvas-container" id="canvas-wrapper">
+              <canvas id="scene" aria-hidden="true"></canvas>
+              <div class="canvas-placeholder" id="canvas-placeholder" data-i18n="placeholderText">
+                Enter your birth date to generate your unique aura pattern
+              </div>
+              <button
+                class="canvas-toggle"
+                id="canvas-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="scene"
+              >
+                <span class="canvas-toggle__icon" aria-hidden="true">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="9 3 3 3 3 9"></polyline>
+                    <polyline points="15 21 21 21 21 15"></polyline>
+                    <line x1="3" y1="3" x2="10" y2="10"></line>
+                    <line x1="21" y1="21" x2="14" y2="14"></line>
+                  </svg>
+                </span>
+                <span class="canvas-toggle__label" id="canvas-toggle-label">Expand</span>
+              </button>
             </div>
-            <button
-              class="canvas-toggle"
-              id="canvas-toggle"
-              type="button"
-              aria-expanded="false"
-              aria-controls="scene"
-            >
-              <span class="canvas-toggle__icon" aria-hidden="true">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <polyline points="9 3 3 3 3 9"></polyline>
-                  <polyline points="15 21 21 21 21 15"></polyline>
-                  <line x1="3" y1="3" x2="10" y2="10"></line>
-                  <line x1="21" y1="21" x2="14" y2="14"></line>
-                </svg>
-              </span>
-              <span class="canvas-toggle__label" id="canvas-toggle-label">Expand</span>
-            </button>
-          </div>
+          </section>
           <aside
             class="description-panel"
             id="aura-desc"
             aria-live="polite"
-            aria-label="Опис комбінації Цолькіна"
+            aria-labelledby="aura-desc-title"
           >
             <div class="aura-desc__inner">
               <header class="aura-desc__header">
-                <h2 class="aura-desc__title">
+                <h2 class="aura-desc__title" id="aura-desc-title">
                   <span>Опис</span>
                   <span>Description</span>
                 </h2>


### PR DESCRIPTION
## Summary
- wrap the glyph canvas and description in a persistent `#aura-page` layout with accessible labelling for the description panel
- adjust the description panel styling to stack under the canvas on small screens and form a sticky right column on desktops
- update canvas resizing logic to measure the visual column width so the description column remains visible across breakpoints

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc22b275a08320a5c712c35a0f0542