### PR TITLE
Fix date fallback layout and mobile canvas spacing

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -58,6 +58,8 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
   const modalOverlay = document.getElementById("modal-overlay");
   const modalClose = document.getElementById("modal-close");
 
+  // Зберігаємо посилання на обгортку навколо фолбек-селектів, щоб можна було повністю прибрати її з потоку верстки.
+  const nativeDateControls = document.getElementById("native-date-controls");
   const fallbackInputsContainer = document.getElementById("fallback-inputs");
   const fallbackDay = document.getElementById("daySelect");
   const fallbackMonth = document.getElementById("monthSelect");
@@ -722,7 +724,11 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
     dateInput.hidden = state.usingFallback;
     dateInput.disabled = state.usingFallback;
   }
+  if (nativeDateControls) {
+    nativeDateControls.hidden = !state.usingFallback;
+  }
   if (fallbackInputsContainer) {
+    // Ховаємо або показуємо обгортку з альтернативними селектами, щоб вона не впливала на висоту сітки.
     fallbackInputsContainer.hidden = !state.usingFallback;
   }
 
@@ -1212,7 +1218,12 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
 
     const scale = Math.min(containerWidth / scenesDesignWidth, availableHeight / scenesDesignHeight);
     const offsetX = (containerWidth - scenesDesignWidth * scale) / 2;
-    const offsetY = (availableHeight - scenesDesignHeight * scale) / 2;
+    const extraVerticalSpace = Math.max(availableHeight - scenesDesignHeight * scale, 0);
+    // На мобільних екранах прибираємо надмірне центроване вирівнювання, щоб символ знаходився ближче до верхнього краю.
+    const isNarrowViewport = viewportWidth <= 600;
+    const mobileOffsetCap = 48; // У пікселях: обмеження на верхній відступ, щоби символ не «сповзав» надто низько.
+    const centeredOffsetY = extraVerticalSpace / 2;
+    const offsetY = isNarrowViewport ? Math.min(centeredOffsetY, mobileOffsetCap) : centeredOffsetY;
 
     state.designScale = scale;
     state.designOffsetX = offsetX;

--- a/client/assets/css/topbar.css
+++ b/client/assets/css/topbar.css
@@ -137,9 +137,13 @@
 }
 
 .select--sm select {
-  min-width: 72px;
   text-transform: uppercase;
   font-weight: 600;
+}
+
+/* Допоміжне правило: повністю ховаємо блок фолбек-контролів, якщо він позначений атрибутом hidden. */
+.field-fallback[hidden] {
+  display: none !important;
 }
 
 /* === 3. Додаткові службові блоки === */
@@ -223,6 +227,17 @@
 .mixed-row .field-lang,
 .mixed-row .field-help {
   flex: 0 0 auto;
+}
+
+/* Обмежуємо ширину блоку вибору мови на мобільних, щоб поряд залишалося місце для кнопки. */
+.mixed-row .field-lang .select {
+  width: auto;
+}
+
+.mixed-row .field-lang .select select {
+  width: auto;
+  min-width: 0;
+  padding-right: 28px; /* Трохи зменшуємо відступ під стрілку, аби вміщалися три символи. */
 }
 
 .mixed-row .generate-button {
@@ -315,6 +330,11 @@
     text-align: left;
     padding-left: 12px;
     padding-right: 36px;
+  }
+
+  /* На десктопах повертаємо мінімальну ширину компактним селектам, щоб підпис виглядав врівноважено. */
+  .select--sm select {
+    min-width: 72px;
   }
 
   .icon-btn {


### PR DESCRIPTION
## Summary
- hide the unused native date fallback wrapper when the browser supports input[type=date]
- tune mobile language selector sizing so it stays compact alongside the run button
- limit canvas vertical offset on narrow screens to reduce top padding in the glyph view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd08144c508320a481eeab181f8c32