### PR TITLE
Refactor description generator for bilingual dictionaries

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -113,7 +113,7 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
     console.warn("Не вдалося попередньо завантажити словники опису:", error);
   });
 
-  const DESCRIPTION_BLOCK_ORDER = [
+  const DEFAULT_DESCRIPTION_BLOCK_ORDER = [
     "intro",
     "glyph_core",
     "tone_core",
@@ -375,7 +375,26 @@ window.TZOLKIN_ORDER = TZOLKIN_ORDER;
     descBody.innerHTML = "";
     const isDesktopView = window.matchMedia("(min-width: 1024px)").matches;
 
-    DESCRIPTION_BLOCK_ORDER.forEach((blockKey) => {
+    // Формуємо робочий порядок блоків: спочатку беремо послідовність із бекенду, а потім додаємо дефолт, щоб нічого не пропустити.
+    const combinedOrder = Array.isArray(description.order)
+      ? [...description.order]
+      : [];
+    const blockOrder = [];
+    const fallbackOrder = DEFAULT_DESCRIPTION_BLOCK_ORDER;
+    [...combinedOrder, ...fallbackOrder].forEach((key) => {
+      if (key === "title") {
+        return;
+      }
+      if (!DESCRIPTION_LABELS[key]) {
+        console.warn("Невідомий блок опису пропущено:", key);
+        return;
+      }
+      if (!blockOrder.includes(key)) {
+        blockOrder.push(key);
+      }
+    });
+
+    blockOrder.forEach((blockKey) => {
       const block = description.blocks?.[blockKey];
       const section = document.createElement("details");
       section.className = "aura-desc__section";

--- a/data/glyphs.json
+++ b/data/glyphs.json
@@ -1,322 +1,1082 @@
 {
   "imix": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "ik": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "akbal": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "kan": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "chikchan": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "kimi": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "manik": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "lamat": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "muluk": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "ok": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "chuwen": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "eb": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "ben": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "ix": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "men": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "kib": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "kaban": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "etznab": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "kawak": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "ahau": {
-    "name_ua": "",
-    "name_en": "",
-    "element": "",
-    "archetype": "",
-    "domains": [],
-    "strengths": [],
-    "shadows": [],
-    "imagery": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_verbs": [],
-    "emotions": [],
-    "rituals": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "element": {
+      "ua": "",
+      "en": ""
+    },
+    "archetype": {
+      "ua": "",
+      "en": ""
+    },
+    "domains": {
+      "ua": [],
+      "en": []
+    },
+    "strengths": {
+      "ua": [],
+      "en": []
+    },
+    "shadows": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_verbs": {
+      "ua": [],
+      "en": []
+    },
+    "emotions": {
+      "ua": [],
+      "en": []
+    },
+    "rituals": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   }
 }

--- a/data/rules.json
+++ b/data/rules.json
@@ -1,24 +1,67 @@
 {
-  "order": ["title", "intro", "glyph_core", "tone_core", "synergy", "advice", "shadow", "conclusion"],
+  "order": [
+    "title",
+    "intro",
+    "glyph_core",
+    "tone_core",
+    "synergy",
+    "advice",
+    "shadow",
+    "conclusion"
+  ],
   "composition": {
     "synergy": {
-      "glyph_fields": ["domains", "synergy_verbs", "imagery"],
-      "tone_fields": ["essence", "synergy_patterns", "imagery"]
+      "glyph_fields": [
+        "domains",
+        "synergy_verbs",
+        "imagery"
+      ],
+      "tone_fields": [
+        "essence",
+        "synergy_patterns",
+        "imagery"
+      ]
     },
     "advice": {
-      "glyph_fields": ["advice_short", "advice_long", "rituals"],
-      "tone_fields": ["advice_short", "advice_long", "questions"]
+      "glyph_fields": [
+        "advice_short",
+        "advice_long",
+        "rituals"
+      ],
+      "tone_fields": [
+        "advice_short",
+        "advice_long",
+        "questions"
+      ]
     },
     "shadow": {
-      "glyph_fields": ["shadows"],
-      "tone_fields": ["challenges"]
+      "glyph_fields": [
+        "shadows"
+      ],
+      "tone_fields": [
+        "challenges"
+      ]
     },
     "conclusion": {
-      "glyph_fields": ["archetype", "imagery"],
-      "tone_fields": ["symbol"]
+      "glyph_fields": [
+        "archetype",
+        "imagery"
+      ],
+      "tone_fields": [
+        "symbol"
+      ]
     }
   },
-  "limits": { "title": 70, "meta": 160 },
-  "avoid_repeats": [],
-  "synonyms": {}
+  "limits": {
+    "title": 70,
+    "meta": 160
+  },
+  "avoid_repeats": {
+    "ua": [],
+    "en": []
+  },
+  "synonyms": {
+    "ua": {},
+    "en": {}
+  }
 }

--- a/data/tones.json
+++ b/data/tones.json
@@ -1,171 +1,600 @@
 {
   "1": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "2": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "3": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "4": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "5": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "6": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "7": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "8": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "9": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "10": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "11": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "12": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   },
   "13": {
-    "name_ua": "",
-    "essence": "",
-    "symbol": "",
-    "gifts": [],
-    "challenges": [],
-    "imagery": [],
-    "questions": [],
-    "advice_short": [],
-    "advice_long": [],
-    "synergy_patterns": [],
-    "keywords": []
+    "name": {
+      "ua": "",
+      "en": ""
+    },
+    "essence": {
+      "ua": "",
+      "en": ""
+    },
+    "symbol": {
+      "ua": "",
+      "en": ""
+    },
+    "gifts": {
+      "ua": [],
+      "en": []
+    },
+    "challenges": {
+      "ua": [],
+      "en": []
+    },
+    "imagery": {
+      "ua": [],
+      "en": []
+    },
+    "questions": {
+      "ua": [],
+      "en": []
+    },
+    "advice_short": {
+      "ua": [],
+      "en": []
+    },
+    "advice_long": {
+      "ua": [],
+      "en": []
+    },
+    "synergy_patterns": {
+      "ua": [],
+      "en": []
+    },
+    "keywords": {
+      "ua": [],
+      "en": []
+    }
   }
 }

--- a/utils/generator.js
+++ b/utils/generator.js
@@ -18,12 +18,29 @@ let dictionariesPromise = null;
 const descriptionCache = new Map();
 
 // Значення за замовчуванням для випадку, коли словники відсутні або неповні.
+const DEFAULT_BLOCK_ORDER = [
+  "title",
+  "intro",
+  "glyph_core",
+  "tone_core",
+  "synergy",
+  "advice",
+  "shadow",
+  "conclusion",
+];
+
+const VALID_BLOCK_KEYS = new Set(DEFAULT_BLOCK_ORDER);
+
 const FALLBACK_DESCRIPTION = {
   title: "Опис тимчасово недоступний",
   metaDescription: "Опис для цієї комбінації ще готується.",
   keywords: [],
+  order: DEFAULT_BLOCK_ORDER,
   blocks: {
-    intro: { paragraphs: ["Ми ще збираємо матеріали для цієї комбінації гліфа та тону."], list: [] },
+    intro: {
+      paragraphs: ["Ми ще збираємо матеріали для цієї комбінації гліфа та тону."],
+      list: [],
+    },
     glyph_core: { paragraphs: [], list: [] },
     tone_core: { paragraphs: [], list: [] },
     synergy: { paragraphs: [], list: [] },
@@ -32,6 +49,17 @@ const FALLBACK_DESCRIPTION = {
     conclusion: { paragraphs: [], list: [] },
   },
 };
+
+/**
+ * Швидко формуємо службовий опис для критичних випадків (відсутні дані).
+ */
+function buildServiceFallback(message) {
+  const fallback = cloneResult(FALLBACK_DESCRIPTION);
+  if (message) {
+    fallback.blocks.intro.paragraphs = [normalizeSpacing(message)];
+  }
+  return fallback;
+}
 
 /**
  * Безпечне глибоке клонування результату перед поверненням користувачу.
@@ -120,6 +148,13 @@ function normalizeLang(lang) {
 }
 
 /**
+ * Визначаємо запасну мову: якщо користувач просить українську — підстрахуємо англійською і навпаки.
+ */
+function getFallbackLang(lang) {
+  return lang === "en" ? "ua" : "en";
+}
+
+/**
  * Робимо першу літеру великою, щоб акуратно показувати ID гліфа у fallback-фразах.
  */
 function capitalizeWord(word) {
@@ -128,28 +163,135 @@ function capitalizeWord(word) {
 }
 
 /**
- * Повертаємо масив значень поля або порожній масив, якщо значення відсутнє.
+ * Акуратно читаємо локалізоване значення зі словника та фіксуємо fallback у журналі.
+ * type = 'string' або 'array' вказує, який тип даних очікуємо отримати.
  */
-function arrayField(entry, field) {
+function readLocalized(entry, field, { lang, fallbackLang, type = "string", logContext, source }) {
+  const emptyValue = type === "array" ? [] : "";
   if (!entry || typeof entry !== "object") {
-    return [];
+    return emptyValue;
   }
-  const value = entry[field];
-  if (!value) {
-    return [];
+  const raw = entry[field];
+  if (!raw || typeof raw !== "object") {
+    return emptyValue;
   }
-  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+
+  const directValue = raw[lang];
+  const fallbackValue = raw[fallbackLang];
+
+  const normalize = (value) => {
+    if (type === "array") {
+      if (!value) return [];
+      if (Array.isArray(value)) {
+        return value.filter(Boolean).map((item) => `${item}`.trim()).filter(Boolean);
+      }
+      if (typeof value === "string") {
+        return value.trim() ? [value.trim()] : [];
+      }
+      return [];
+    }
+    if (!value || typeof value !== "string") {
+      return "";
+    }
+    return value.trim();
+  };
+
+  const normalizedDirect = normalize(directValue);
+  const hasDirectData = type === "array" ? normalizedDirect.length > 0 : normalizedDirect.length > 0;
+  if (hasDirectData) {
+    return type === "array" ? [...normalizedDirect] : normalizedDirect;
+  }
+
+  const normalizedFallback = normalize(fallbackValue);
+  const hasFallbackData = type === "array" ? normalizedFallback.length > 0 : normalizedFallback.length > 0;
+  if (hasFallbackData) {
+    if (logContext && source) {
+      logContext.fallbacks.push(`fallback used: ${source}.${fallbackLang}`);
+    }
+    return type === "array" ? [...normalizedFallback] : normalizedFallback;
+  }
+
+  return emptyValue;
 }
 
 /**
- * Збираємо значення кількох полів в один масив.
+ * Спеціалізований зчитувач масивів зі словників гліфа та тону.
  */
-function gatherFields(entry, fields) {
+function readLocalizedList(entry, field, options) {
+  return readLocalized(entry, field, { ...options, type: "array" });
+}
+
+/**
+ * Отримуємо масиви модифікаторів статі з урахуванням fallback і логування.
+ */
+function readGenderList(genderEntry, key, { lang, fallbackLang, logContext }) {
+  if (!genderEntry || typeof genderEntry !== "object") {
+    return [];
+  }
+  const raw = genderEntry[key];
+  if (!raw || typeof raw !== "object") {
+    return [];
+  }
+  const direct = Array.isArray(raw[lang]) ? raw[lang].filter(Boolean) : [];
+  if (direct.length > 0) {
+    return [...direct];
+  }
+  const fallback = Array.isArray(raw[fallbackLang]) ? raw[fallbackLang].filter(Boolean) : [];
+  if (fallback.length > 0) {
+    if (logContext) {
+      logContext.fallbacks.push(`fallback used: gender.${key}.${fallbackLang}`);
+    }
+    return [...fallback];
+  }
+  return [];
+}
+
+/**
+ * Збираємо усі значення зазначених полів для конкретної мови (з урахуванням fallback).
+ */
+function collectLocalizedFields(entry, fields, options) {
   const result = [];
   fields.forEach((field) => {
-    result.push(...arrayField(entry, field));
+    result.push(...readLocalizedList(entry, field, { ...options, source: `${options.source}.${field}` }));
   });
-  return result;
+  return result.filter(Boolean);
+}
+
+/**
+ * Формуємо мапу полів -> списків значень для подальшої гнучкої композиції.
+ */
+function collectFieldMap(entry, fields, options) {
+  const map = new Map();
+  fields.forEach((field) => {
+    const values = readLocalizedList(entry, field, { ...options, source: `${options.source}.${field}` });
+    if (values.length > 0) {
+      map.set(field, values);
+    }
+  });
+  return map;
+}
+
+/**
+ * Оцінюємо, чи достатньо у блоці словникових фраз (квоту фіксуємо у порушеннях).
+ */
+function evaluateDictionaryDensity(sentences, dictionaryPieces, threshold, label, logContext) {
+  if (!sentences || sentences.length === 0) {
+    return;
+  }
+  const plainText = normalizeSpacing(sentences.join(" "));
+  if (!plainText) {
+    return;
+  }
+  const totalLength = plainText.length;
+  const dictionaryText = normalizeSpacing(dictionaryPieces.join(" "));
+  const dictionaryLength = dictionaryText.length;
+  if (totalLength === 0) {
+    return;
+  }
+  const ratio = dictionaryLength / totalLength;
+  if (ratio < threshold) {
+    logContext.violations.push(`${label}:dictionary_ratio:${Math.round(ratio * 100)}%<${Math.round(threshold * 100)}%`);
+  }
 }
 
 /**
@@ -184,7 +326,11 @@ function truncate(text, limit) {
  * Прибираємо надмірні пробіли та пробіли перед розділовими знаками.
  */
 function normalizeSpacing(text) {
-  return text.replace(/\s+/g, " ").replace(/\s([.,!?:;])/g, "$1").trim();
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/\s([.,!?:;])/g, "$1")
+    .replace(/([.!?]){2,}/g, "$1")
+    .trim();
 }
 
 /**
@@ -252,7 +398,7 @@ function applyLexShifts(text, lexShift = []) {
 /**
  * Будуємо заголовок з імен гліфа і тону, дотримуючись обмежень довжини.
  */
-function buildTitle({ glyphName, toneName, toneId, toneEssence, limits }) {
+function buildTitle({ glyphName, toneName, toneId, toneEssence, genderLabel, limits, logContext }) {
   const parts = [];
   if (glyphName) {
     parts.push(glyphName);
@@ -264,8 +410,15 @@ function buildTitle({ glyphName, toneName, toneId, toneEssence, limits }) {
   if (toneEssence) {
     parts.push(takeWords(toneEssence, 6));
   }
-  const rawTitle = parts.join(" • ");
-  return truncate(rawTitle || "Опис", limits.title || 70);
+  if (genderLabel) {
+    parts.push(genderLabel);
+  }
+  const rawTitle = parts.filter(Boolean).join(" • ") || "Опис";
+  const limited = truncate(rawTitle, limits.title || 70);
+  if (logContext && limited !== rawTitle) {
+    logContext.violations.push(`title:truncated>${limits.title || 70}`);
+  }
+  return limited;
 }
 
 /**
@@ -281,10 +434,14 @@ function finalizeSection(sentences, avoidRepeats, synonyms) {
 /**
  * Формуємо коротку мета-опис, комбінуючи перші речення з intro та synergy.
  */
-function buildMetaDescription({ intro, synergy, limits }) {
+function buildMetaDescription({ intro, synergy, limits, logContext }) {
   const base = [intro?.[0], synergy?.[0]].filter(Boolean).join(" ");
   const normalized = normalizeSpacing(base || "Опис комбінації гліфа та тону Цолькін.");
-  return truncate(normalized, limits.meta || 160);
+  const limited = truncate(normalized, limits.meta || 160);
+  if (logContext && limited !== normalized) {
+    logContext.violations.push(`meta:truncated>${limits.meta || 160}`);
+  }
+  return limited;
 }
 
 /**
@@ -314,142 +471,438 @@ function composeDescription({
   rules,
   glyphId,
   toneId,
+  gender,
   lang,
+  logContext,
 }) {
+  const fallbackLang = getFallbackLang(lang);
   const limits = rules?.limits || { title: 70, meta: 160 };
-  const avoidRepeats = Array.isArray(rules?.avoid_repeats) ? rules.avoid_repeats : [];
-  const synonyms = rules?.synonyms || {};
+  const avoidRepeats = Array.isArray(rules?.avoid_repeats?.[lang]) ? rules.avoid_repeats[lang] : [];
+  const synonyms = rules?.synonyms?.[lang] || {};
 
-  const glyphName = lang === "en" ? glyphEntry.name_en || capitalizeWord(glyphId) : glyphEntry.name_ua || capitalizeWord(glyphId);
-  const toneName = lang === "en" ? toneEntry.name_en || toneEntry.name_ua : toneEntry.name_ua;
-  const toneEssence = toneEntry.essence || "";
+  const orderCandidate = Array.isArray(rules?.order) ? rules.order.filter((key) => typeof key === "string") : [];
+  const filteredOrder = orderCandidate.filter((key) => {
+    if (!VALID_BLOCK_KEYS.has(key)) {
+      logContext.violations.push(`order:invalid:${key}`);
+      return false;
+    }
+    return true;
+  });
+  const uniqueOrder = Array.from(new Set(filteredOrder));
+  if (uniqueOrder.length > 0 && !uniqueOrder.includes("title")) {
+    uniqueOrder.unshift("title");
+    logContext.violations.push("order:missing:title");
+  }
+  const order = uniqueOrder.length > 0 ? uniqueOrder : DEFAULT_BLOCK_ORDER;
 
-  const title = buildTitle({ glyphName, toneName, toneId, toneEssence, limits });
+  const glyphName =
+    readLocalized(glyphEntry, "name", {
+      lang,
+      fallbackLang,
+      logContext,
+      source: `glyph.${glyphId}.name`,
+    }) || capitalizeWord(glyphId);
+  const toneName = readLocalized(toneEntry, "name", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.name`,
+  });
+  const toneEssence = readLocalized(toneEntry, "essence", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.essence`,
+  });
+  const toneSymbol = readLocalized(toneEntry, "symbol", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.symbol`,
+  });
+  const glyphArchetype = readLocalized(glyphEntry, "archetype", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}.archetype`,
+  });
 
+  const genderLexShift = readGenderList(genderEntry, "lex_shift", { lang, fallbackLang, logContext });
+  const genderAddresses = readGenderList(genderEntry, "address", { lang, fallbackLang, logContext });
+  const genderToneStyle = readGenderList(genderEntry, "tone_style", { lang, fallbackLang, logContext });
+  const genderAdvicePrefixes = readGenderList(genderEntry, "advice_prefixes", { lang, fallbackLang, logContext });
+  const genderConclusionClosers = readGenderList(genderEntry, "conclusion_closers", { lang, fallbackLang, logContext });
+  const genderAcknowledgements = readGenderList(genderEntry, "acknowledgements", { lang, fallbackLang, logContext });
+
+  const genderLabel =
+    lang === "en"
+      ? gender === "male"
+        ? "Male focus"
+        : "Female focus"
+      : gender === "male"
+      ? "Чоловічий фокус"
+      : "Жіночий фокус";
+
+  const title = buildTitle({
+    glyphName,
+    toneName,
+    toneId,
+    toneEssence,
+    genderLabel,
+    limits,
+    logContext,
+  });
+
+  // --- Вступ ---
   const introSentences = [];
-  if (glyphEntry.archetype) {
-    introSentences.push(`${glyphName} — ${glyphEntry.archetype}.`);
+  const addressPart = genderAddresses[0] ? `${genderAddresses[0]}. ` : "";
+  if (glyphArchetype) {
+    introSentences.push(
+      applyLexShifts(`${addressPart}${glyphName} — ${glyphArchetype}.`, genderLexShift)
+    );
   }
   if (toneEssence) {
-    introSentences.push(`Тон ${toneId} задає ритм: ${toneEssence}.`);
+    introSentences.push(
+      applyLexShifts(`Тон ${toneId} підсилює цю історію як ${toneEssence}.`, genderLexShift)
+    );
   }
   if (introSentences.length === 0) {
-    introSentences.push(`Комбінація ${capitalizeWord(glyphId)} та тону ${toneId} ще очікує на детальний опис.`);
+    const fallbackIntro = `${addressPart}Комбінація ${capitalizeWord(glyphId)} з тоном ${toneId} ще очікує на опис.`.trim();
+    introSentences.push(fallbackIntro);
+    logContext.violations.push("intro:fallback");
   }
 
+  // --- Блок гліфа ---
   const glyphCoreSentences = [];
-  const strengths = arrayField(glyphEntry, "strengths");
-  const domains = arrayField(glyphEntry, "domains");
-  if (strengths.length > 0) {
-    glyphCoreSentences.push(`Сильні сторони: ${formatList(strengths)}.`);
+  const glyphDomains = readLocalizedList(glyphEntry, "domains", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}.domains`,
+  });
+  const glyphStrengths = readLocalizedList(glyphEntry, "strengths", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}.strengths`,
+  });
+  const glyphImagery = readLocalizedList(glyphEntry, "imagery", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}.imagery`,
+  });
+  if (glyphArchetype) {
+    glyphCoreSentences.push(
+      applyLexShifts(`${glyphName} проживає архетип: ${glyphArchetype}.`, genderLexShift)
+    );
   }
-  if (domains.length > 0) {
-    glyphCoreSentences.push(`Сфери впливу: ${formatList(domains)}.`);
+  if (glyphStrengths.length > 0) {
+    glyphCoreSentences.push(
+      applyLexShifts(`Сильні сторони: ${formatList(glyphStrengths)}.`, genderLexShift)
+    );
   }
-  const glyphImagery = arrayField(glyphEntry, "imagery");
+  if (glyphDomains.length > 0) {
+    glyphCoreSentences.push(
+      applyLexShifts(`Ключові сфери: ${formatList(glyphDomains)}.`, genderLexShift)
+    );
+  }
   if (glyphImagery.length > 0) {
-    glyphCoreSentences.push(`Образи гліфа: ${formatList(glyphImagery)}.`);
+    glyphCoreSentences.push(
+      applyLexShifts(`Образи, що підтримують: ${formatList(glyphImagery)}.`, genderLexShift)
+    );
+  }
+  if (glyphCoreSentences.length === 0) {
+    glyphCoreSentences.push(
+      applyLexShifts(`${glyphName} запрошує дослідити власний ритм і поступ.`, genderLexShift)
+    );
+    logContext.violations.push("glyph_core:fallback");
   }
 
+  // --- Блок тону ---
   const toneCoreSentences = [];
-  const gifts = arrayField(toneEntry, "gifts");
-  const challenges = arrayField(toneEntry, "challenges");
+  const toneGifts = readLocalizedList(toneEntry, "gifts", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.gifts`,
+  });
+  const toneChallenges = readLocalizedList(toneEntry, "challenges", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.challenges`,
+  });
+  const toneImagery = readLocalizedList(toneEntry, "imagery", {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}.imagery`,
+  });
   if (toneEssence) {
-    toneCoreSentences.push(`Суть тону: ${toneEssence}.`);
+    toneCoreSentences.push(`Суть тону ${toneId}: ${toneEssence}.`);
   }
-  if (gifts.length > 0) {
-    toneCoreSentences.push(`Подарунки тону: ${formatList(gifts)}.`);
+  if (toneGifts.length > 0) {
+    toneCoreSentences.push(`Подарунки: ${formatList(toneGifts)}.`);
   }
-  if (challenges.length > 0) {
-    toneCoreSentences.push(`Виклики: ${formatList(challenges)}.`);
+  if (toneChallenges.length > 0) {
+    toneCoreSentences.push(`Виклики: ${formatList(toneChallenges)}.`);
   }
-  const toneImagery = arrayField(toneEntry, "imagery");
   if (toneImagery.length > 0) {
     toneCoreSentences.push(`Образи тону: ${formatList(toneImagery)}.`);
   }
+  if (toneCoreSentences.length === 0) {
+    toneCoreSentences.push(`Тон ${toneId} потребує додаткових матеріалів для розгорнутого опису.`);
+    logContext.violations.push("tone_core:fallback");
+  }
 
+  // --- Синергія ---
   const synergyPlan = rules?.composition?.synergy || { glyph_fields: [], tone_fields: [] };
-  const synergyGlyphValues = gatherFields(glyphEntry, synergyPlan.glyph_fields || []);
-  const synergyToneValues = gatherFields(toneEntry, synergyPlan.tone_fields || []);
+  const synergyGlyphMap = collectFieldMap(glyphEntry, synergyPlan.glyph_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}`,
+  });
+  const synergyToneMap = collectFieldMap(toneEntry, synergyPlan.tone_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}`,
+  });
   const synergySentences = [];
-  if (synergyGlyphValues.length > 0 || synergyToneValues.length > 0) {
-    const glyphPhrase = synergyGlyphValues.length > 0 ? formatList(synergyGlyphValues) : null;
-    const tonePhrase = synergyToneValues.length > 0 ? formatList(synergyToneValues) : null;
-    if (glyphPhrase && tonePhrase) {
-      synergySentences.push(`У дії цей союз проявляється через ${glyphPhrase}, доповнені тоном як ${tonePhrase}.`);
-    } else if (glyphPhrase) {
-      synergySentences.push(`Гліф підказує зосередитися на ${glyphPhrase}.`);
-    } else if (tonePhrase) {
-      synergySentences.push(`Ритм тону веде до ${tonePhrase}.`);
+  const synergyFragments = [];
+
+  const synergyDomains = synergyGlyphMap.get("domains") || [];
+  const synergyVerbs = synergyGlyphMap.get("synergy_verbs") || [];
+  const synergyGlyphImagery = synergyGlyphMap.get("imagery") || [];
+  if (synergyDomains.length > 0 || synergyVerbs.length > 0) {
+    const domainPart = synergyDomains.length > 0 ? `сфери ${formatList(synergyDomains)}` : null;
+    const verbPart = synergyVerbs.length > 0 ? `спонукають до ${formatList(synergyVerbs)}` : null;
+    const combined = [domainPart, verbPart].filter(Boolean).join(", ");
+    if (combined) {
+      synergySentences.push(
+        applyLexShifts(`Гліф спрямовує у ${combined}.`, genderLexShift)
+      );
+      synergyFragments.push(...synergyDomains, ...synergyVerbs);
     }
   }
 
-  const advicePlan = rules?.composition?.advice || { glyph_fields: [], tone_fields: [] };
-  const adviceGlyph = gatherFields(glyphEntry, advicePlan.glyph_fields || []);
-  const adviceTone = gatherFields(toneEntry, advicePlan.tone_fields || []);
-  const adviceItems = [...adviceGlyph, ...adviceTone];
-  if (adviceItems.length === 0) {
-    adviceItems.push("Зачекайте на заповнення порад для цієї комбінації.");
+  const synergyToneEssence = toneEssence;
+  const synergyPatterns = synergyToneMap.get("synergy_patterns") || [];
+  const synergyToneImagery = synergyToneMap.get("imagery") || [];
+  if (synergyToneEssence || synergyPatterns.length > 0) {
+    const patternPart = synergyPatterns.length > 0 ? `через ${formatList(synergyPatterns)}` : "";
+    const sentence = `Тон ${toneId} розкриває потенціал як ${synergyToneEssence || "живий ритм"} ${patternPart}`.trim();
+    synergySentences.push(applyLexShifts(`${sentence}.`, genderLexShift));
+    if (synergyToneEssence) synergyFragments.push(synergyToneEssence);
+    synergyFragments.push(...synergyPatterns);
   }
-  const genderToneStyle = Array.isArray(genderEntry?.tone_style) ? genderEntry.tone_style : [];
-  const tonePrefix = genderToneStyle[0] || "Рекомендації";
-  const adviceList = adviceItems.map((item) => applyLexShifts(`${tonePrefix}: ${item}`, genderEntry?.lex_shift));
 
+  if (synergyGlyphImagery.length > 0 || synergyToneImagery.length > 0) {
+    const imageryPhrase = [
+      synergyGlyphImagery.length > 0 ? `образи гліфа ${formatList(synergyGlyphImagery)}` : null,
+      synergyToneImagery.length > 0 ? `відгукуються з тоном як ${formatList(synergyToneImagery)}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    if (imageryPhrase) {
+      synergySentences.push(applyLexShifts(`Разом це виглядає як ${imageryPhrase}.`, genderLexShift));
+      synergyFragments.push(...synergyGlyphImagery, ...synergyToneImagery);
+    }
+  }
+
+  if (synergySentences.length < 2) {
+    synergySentences.push(
+      applyLexShifts(
+        "Союз гліфа та тону поступово наповнюється новими сенсами — дочекайтеся оновлення опису.",
+        genderLexShift
+      )
+    );
+    logContext.violations.push("synergy:fallback");
+  }
+
+  // --- Поради ---
+  const advicePlan = rules?.composition?.advice || { glyph_fields: [], tone_fields: [] };
+  const adviceGlyphItems = collectLocalizedFields(glyphEntry, advicePlan.glyph_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}`,
+  });
+  const adviceToneItems = collectLocalizedFields(toneEntry, advicePlan.tone_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}`,
+  });
+  const adviceItems = [...adviceGlyphItems, ...adviceToneItems];
+  const adviceList = [];
+  if (adviceItems.length === 0) {
+    adviceItems.push("Поради для цієї комбінації наразі готуються.");
+    logContext.violations.push("advice:fallback");
+  }
+  const adviceFragments = [...adviceItems];
+  adviceItems.forEach((item, index) => {
+    const prefix = genderAdvicePrefixes[index % Math.max(genderAdvicePrefixes.length, 1)] ||
+      (lang === "en" ? "Focus on" : "Зверни увагу на");
+    const toneStylePart = genderToneStyle[index % Math.max(genderToneStyle.length, 1)] || "";
+    const combined = `${prefix} ${item}${toneStylePart ? ` (${toneStylePart})` : ""}`;
+    adviceList.push(applyLexShifts(normalizeSpacing(combined), genderLexShift));
+  });
+  if (adviceList.length < 3 && adviceList.length > 0) {
+    const duplicated = [...adviceList];
+    while (duplicated.length < 3) {
+      duplicated.push(adviceList[duplicated.length % adviceList.length]);
+    }
+    adviceList.splice(0, adviceList.length, ...duplicated);
+    logContext.violations.push("advice:duplicated_to_reach_minimum");
+  }
+
+  const adviceParagraphs = [];
+  if (genderToneStyle.length > 0) {
+    adviceParagraphs.push(normalizeSpacing(applyLexShifts(genderToneStyle[0], genderLexShift)));
+  }
+
+  // --- Тінь ---
   const shadowPlan = rules?.composition?.shadow || { glyph_fields: [], tone_fields: [] };
-  const shadowGlyph = gatherFields(glyphEntry, shadowPlan.glyph_fields || []);
-  const shadowTone = gatherFields(toneEntry, shadowPlan.tone_fields || []);
+  const shadowGlyph = collectLocalizedFields(glyphEntry, shadowPlan.glyph_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}`,
+  });
+  const shadowTone = collectLocalizedFields(toneEntry, shadowPlan.tone_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}`,
+  });
   const shadowSentences = [];
   if (shadowGlyph.length > 0) {
-    shadowSentences.push(`Тінь гліфа: ${formatList(shadowGlyph)}.`);
+    shadowSentences.push(`Тінь гліфа проявляється через ${formatList(shadowGlyph)}.`);
   }
   if (shadowTone.length > 0) {
-    const neutralizer = adviceGlyph[0] || adviceTone[0];
-    if (neutralizer) {
-      shadowSentences.push(`Баланс підтримує порада: ${neutralizer}.`);
-    } else {
-      shadowSentences.push(`Виклики тону: ${formatList(shadowTone)}.`);
-    }
+    shadowSentences.push(`Ризики тону: ${formatList(shadowTone)}.`);
+  }
+  const neutralizer = adviceItems[0];
+  if (neutralizer) {
+    shadowSentences.push(`Пом’якшити допоможе: ${neutralizer}.`);
+  }
+  const shadowFragments = [...shadowGlyph, ...shadowTone];
+  if (neutralizer) {
+    shadowFragments.push(neutralizer);
+  }
+  if (shadowSentences.length === 0) {
+    shadowSentences.push("Тіньові аспекти ще уточнюються командою авторів.");
+    logContext.violations.push("shadow:fallback");
   }
 
+  // --- Висновок ---
   const conclusionPlan = rules?.composition?.conclusion || { glyph_fields: [], tone_fields: [] };
-  const conclusionGlyph = gatherFields(glyphEntry, conclusionPlan.glyph_fields || []);
-  const conclusionTone = gatherFields(toneEntry, conclusionPlan.tone_fields || []);
+  const conclusionGlyph = collectLocalizedFields(glyphEntry, conclusionPlan.glyph_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `glyph.${glyphId}`,
+  });
+  const conclusionTone = collectLocalizedFields(toneEntry, conclusionPlan.tone_fields || [], {
+    lang,
+    fallbackLang,
+    logContext,
+    source: `tone.${toneId}`,
+  });
   const conclusionSentences = [];
-  const address = Array.isArray(genderEntry?.address) && genderEntry.address.length > 0 ? `${genderEntry.address[0]}, ` : "";
-  if (conclusionGlyph.length > 0 || conclusionTone.length > 0) {
-    const glyphSummary = formatList(conclusionGlyph);
-    const toneSummary = formatList(conclusionTone);
-    const sentence = `${address}${glyphSummary || "Цей шлях"} веде до символу тону ${toneSummary || toneId}.`;
-    conclusionSentences.push(applyLexShifts(sentence, genderEntry?.lex_shift));
+  if (glyphArchetype) {
+    conclusionSentences.push(
+      applyLexShifts(`${glyphName} підсумовує шлях як ${glyphArchetype}.`, genderLexShift)
+    );
+  }
+  if (conclusionTone.length > 0 || toneSymbol) {
+    const toneSummary = toneSymbol || formatList(conclusionTone);
+    conclusionSentences.push(
+      applyLexShifts(`Тон ${toneId} закарбовує символ: ${toneSummary}.`, genderLexShift)
+    );
+  }
+  if (genderConclusionClosers.length > 0) {
+    conclusionSentences.push(applyLexShifts(genderConclusionClosers[0], genderLexShift));
+  }
+  if (genderAcknowledgements.length > 0) {
+    conclusionSentences.push(applyLexShifts(genderAcknowledgements[0], genderLexShift));
   }
   if (conclusionSentences.length === 0) {
-    conclusionSentences.push(`${address}Опис для цієї комбінації буде доповнено найближчим часом.`.trim());
+    conclusionSentences.push("Завершальний абзац доповнимо, щойно з’являться дані.");
+    logContext.violations.push("conclusion:fallback");
   }
+  const conclusionFragments = [
+    glyphArchetype,
+    ...conclusionGlyph,
+    toneSymbol,
+    ...conclusionTone,
+    ...genderConclusionClosers,
+    ...genderAcknowledgements,
+  ].filter(Boolean);
 
   const intro = finalizeSection(introSentences, avoidRepeats, synonyms);
   const glyphCore = finalizeSection(glyphCoreSentences, avoidRepeats, synonyms);
   const toneCore = finalizeSection(toneCoreSentences, avoidRepeats, synonyms);
   const synergy = finalizeSection(synergySentences, avoidRepeats, synonyms);
-  const advice = adviceList.filter(Boolean).map((item) => sanitizeRepeats(normalizeSpacing(item), avoidRepeats, synonyms));
+  const adviceListNormalized = adviceList
+    .filter(Boolean)
+    .map((item) => sanitizeRepeats(normalizeSpacing(item), avoidRepeats, synonyms));
   const shadow = finalizeSection(shadowSentences, avoidRepeats, synonyms);
   const conclusion = finalizeSection(conclusionSentences, avoidRepeats, synonyms);
 
-  const metaDescription = buildMetaDescription({ intro, synergy, limits });
-  const keywords = buildKeywords(arrayField(glyphEntry, "keywords"), arrayField(toneEntry, "keywords"));
+  evaluateDictionaryDensity(synergy, synergyFragments, 0.7, "synergy", logContext);
+  evaluateDictionaryDensity(adviceParagraphs.concat(adviceListNormalized), adviceFragments, 0.6, "advice", logContext);
+  evaluateDictionaryDensity(shadow, shadowFragments, 0.8, "shadow", logContext);
+  evaluateDictionaryDensity(conclusion, conclusionFragments, 0.6, "conclusion", logContext);
+
+  const metaDescription = buildMetaDescription({ intro, synergy, limits, logContext });
+
+  const keywords = buildKeywords(
+    readLocalizedList(glyphEntry, "keywords", {
+      lang,
+      fallbackLang,
+      logContext,
+      source: `glyph.${glyphId}.keywords`,
+    }),
+    readLocalizedList(toneEntry, "keywords", {
+      lang,
+      fallbackLang,
+      logContext,
+      source: `tone.${toneId}.keywords`,
+    })
+  );
+
+  if (metaDescription) {
+    const lowerMeta = metaDescription.slice(0, limits.meta || 160).toLowerCase();
+    avoidRepeats.forEach((word) => {
+      if (!word) return;
+      const escaped = word.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const matches = lowerMeta.match(new RegExp(`\\b${escaped}\\b`, "g"));
+      if (matches && matches.length > 1) {
+        logContext.violations.push(`meta:repeat:${word}`);
+      }
+    });
+  }
+
+  const blocks = {
+    intro: { paragraphs: intro, list: [] },
+    glyph_core: { paragraphs: glyphCore, list: [] },
+    tone_core: { paragraphs: toneCore, list: [] },
+    synergy: { paragraphs: synergy, list: [] },
+    advice: { paragraphs: adviceParagraphs, list: adviceListNormalized },
+    shadow: { paragraphs: shadow, list: [] },
+    conclusion: { paragraphs: conclusion, list: [] },
+  };
 
   return {
     title,
     metaDescription,
     keywords,
-    blocks: {
-      intro: { paragraphs: intro, list: [] },
-      glyph_core: { paragraphs: glyphCore, list: [] },
-      tone_core: { paragraphs: toneCore, list: [] },
-      synergy: { paragraphs: synergy, list: [] },
-      advice: { paragraphs: [], list: advice },
-      shadow: { paragraphs: shadow, list: [] },
-      conclusion: { paragraphs: conclusion, list: [] },
-    },
+    order,
+    blocks,
   };
 }
 
@@ -461,20 +914,43 @@ export async function generateDescription({ glyphId, toneId, gender = "female", 
   const normalizedLang = normalizeLang(lang);
   const cacheKey = `${glyphId || ""}-${toneId || ""}-${normalizedGender}-${normalizedLang}`;
 
+  // Готуємо контекст для логування, щоб легко відстежувати звідки з’являються фрази та fallback-и.
+  const logContext = {
+    glyphId: glyphId || "",
+    toneId: toneId ? String(toneId) : "",
+    gender: normalizedGender,
+    lang: normalizedLang,
+    usedOverride: false,
+    fallbacks: [],
+    violations: [],
+  };
+
   if (descriptionCache.has(cacheKey)) {
-    return cloneResult(descriptionCache.get(cacheKey));
+    const cached = cloneResult(descriptionCache.get(cacheKey));
+    const cacheLog = { ...logContext, cacheHit: true };
+    console.info("Aura description cache hit", cacheLog);
+    return cached;
   }
 
   const dictionaries = await loadDictionaries();
   if (!glyphId || !toneId) {
-    descriptionCache.set(cacheKey, FALLBACK_DESCRIPTION);
-    return cloneResult(FALLBACK_DESCRIPTION);
+    logContext.violations.push("missing:ids");
+    const message =
+      normalizedLang === "en"
+        ? "Description temporarily unavailable: missing identifiers."
+        : "Опис недоступний: бракує ідентифікаторів гліфа або тону.";
+    const fallback = buildServiceFallback(message);
+    descriptionCache.set(cacheKey, fallback);
+    console.error("Aura description service fallback", logContext);
+    return cloneResult(fallback);
   }
 
   const overridesKey = `${glyphId}-${toneId}-${normalizedGender}`;
   const override = dictionaries.overrides?.[overridesKey];
   if (override) {
+    logContext.usedOverride = true;
     descriptionCache.set(cacheKey, override);
+    console.info("Aura description override used", logContext);
     return cloneResult(override);
   }
 
@@ -482,8 +958,15 @@ export async function generateDescription({ glyphId, toneId, gender = "female", 
   const toneEntry = dictionaries.tones?.[String(toneId)];
 
   if (!glyphEntry || !toneEntry) {
-    descriptionCache.set(cacheKey, FALLBACK_DESCRIPTION);
-    return cloneResult(FALLBACK_DESCRIPTION);
+    logContext.violations.push("missing:dictionary_entry");
+    const message =
+      normalizedLang === "en"
+        ? `We are still preparing the description for ${glyphId} + tone ${toneId}.`
+        : `Ми ще готуємо опис для ${glyphId} та тону ${toneId}.`;
+    const fallback = buildServiceFallback(message);
+    descriptionCache.set(cacheKey, fallback);
+    console.error("Aura description dictionary fallback", logContext);
+    return cloneResult(fallback);
   }
 
   const genderEntry = dictionaries.genderMods?.[normalizedGender] || {};
@@ -494,10 +977,13 @@ export async function generateDescription({ glyphId, toneId, gender = "female", 
     rules: dictionaries.rules,
     glyphId,
     toneId: String(toneId),
+    gender: normalizedGender,
     lang: normalizedLang,
+    logContext,
   });
 
   descriptionCache.set(cacheKey, description);
+  console.info("Aura description generated", logContext);
   return cloneResult(description);
 }
 


### PR DESCRIPTION
## Summary
- restructure the glyph, tone, and rules dictionaries into true bilingual layouts for localization support
- overhaul the description generator to read localized content with fallbacks, enforce composition rules, and log overrides and quota violations
- update the front-end renderer to honor server-defined block ordering while preserving legacy defaults

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dd1aa2faa8832087377e87387e3196