### PR TITLE
feat: add dynamic address selection

### DIFF
--- a/data/rules.json
+++ b/data/rules.json
@@ -63,5 +63,45 @@
   "synonyms": {
     "ua": {},
     "en": {}
+  },
+  "address_selection": {
+    "mode": "deterministic",
+    "rotation_scope": "week",
+    "fallback": {
+      "ua": "Твій шлях",
+      "en": "Your path"
+    }
+  },
+  "address_tone_map": {
+    "ua": {
+      "1": ["Твій намір", "Твій фокус"],
+      "2": ["Твій вибір", "Твоя рівновага"],
+      "3": ["Твій ритм", "Твій курс"],
+      "4": ["Твоя стратегія", "Твоя опора"],
+      "5": ["Твоя сила", "Твоя опора"],
+      "6": ["Твій ритм", "Твій курс"],
+      "7": ["Твоє світло"],
+      "8": ["Твоя рівновага", "Твоя відповідальність"],
+      "9": ["Твій курс", "Твоя стратегія"],
+      "10": ["Твій результат", "Твоя відповідальність"],
+      "11": ["Твоя стратегія", "Твій вибір"],
+      "12": ["Твій шлях"],
+      "13": ["Твоє світло", "Твій шлях"]
+    },
+    "en": {
+      "1": ["Your intention", "Your focus"],
+      "2": ["Your choice", "Your balance"],
+      "3": ["Your rhythm", "Your course"],
+      "4": ["Your strategy", "Your anchor"],
+      "5": ["Your strength", "Your anchor"],
+      "6": ["Your rhythm", "Your course"],
+      "7": ["Your light"],
+      "8": ["Your balance", "Your responsibility"],
+      "9": ["Your course", "Your strategy"],
+      "10": ["Your result", "Your responsibility"],
+      "11": ["Your strategy", "Your choice"],
+      "12": ["Your path"],
+      "13": ["Your light", "Your path"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- extend rules with address selection configuration and tone-based address mapping
- add a helper in the generator to deterministically select gender-specific addresses with optional rotation
- inject the selected addresses into intro, conclusion, and advice blocks while preserving existing APIs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3879a53883208e235382b9e5ada0