### PR TITLE
Integrate admin worlds view into SPA

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -375,4 +375,105 @@ body {
   }
 }
 
+/* === SPA-навігація та адмінський екран === */
+.app-nav {
+  /* Простий горизонтальний бар для перемикання між ігровим режимом та адмінкою */
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--outline);
+}
+
+.app-nav__btn {
+  /* Кнопки виглядають однаково, активний стан підсвічуємо окремо */
+  border: 1px solid var(--outline);
+  background: transparent;
+  color: var(--text-main);
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.app-nav__btn.is-active {
+  /* Активна вкладка стає синьою, щоб користувач бачив поточний розділ */
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.screen[hidden] {
+  /* Швидко приховуємо цілі секції без зайвого споживання ресурсів */
+  display: none !important;
+}
+
+.admin-panel {
+  /* Базове обрамлення для адмінського списку серверів */
+  max-width: 1200px;
+  margin: 24px auto;
+  padding: 24px 16px;
+  background: var(--bg-panel, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--outline);
+  border-radius: 12px;
+  color: var(--text-main);
+}
+
+.admin-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.admin-panel__title {
+  font-size: 1.4rem;
+  margin: 0;
+}
+
+.admin-panel__hint {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.admin-panel__state {
+  padding: 12px;
+  border: 1px dashed var(--outline);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.admin-panel__state--error {
+  border-color: #ef4444;
+  color: #fca5a5;
+}
+
+.admin-panel__table {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--outline);
+  text-align: left;
+}
+
+.admin-table th {
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.admin-table tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
 

--- a/index.html
+++ b/index.html
@@ -94,6 +94,12 @@
   <body>
     <div id="aura" data-gender="unspecified">
       <div class="app">
+        <nav class="app-nav" aria-label="Основна навігація SPA">
+          <button type="button" class="app-nav__btn is-active" data-nav="play">Грати</button>
+          <button type="button" class="app-nav__btn" data-nav="admin">Адмінка</button>
+        </nav>
+
+        <section class="screen" data-screen="play">
       <header class="header">
         <h1 class="title">AURA</h1>
         <p class="subtitle" id="subtitle" data-i18n="subtitle">
@@ -303,33 +309,62 @@
           </ul>
         </nav>
       </footer>
+        </section>
+
+        <section class="screen admin-screen" data-screen="adminWorlds" hidden>
+          <div class="admin-panel">
+            <header class="admin-panel__header">
+              <h2 class="admin-panel__title">Адмінка: Сервери</h2>
+              <p class="admin-panel__hint">
+                Тут відображається список серверів і їхній стан. Таблиця завантажиться після перевірки доступу.
+              </p>
+            </header>
+            <div class="admin-panel__state" data-role="admin-worlds-state" aria-live="polite">
+              Loading...
+            </div>
+            <div class="admin-panel__table" data-role="admin-worlds-table" hidden>
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th scope="col">ID</th>
+                    <th scope="col">Name</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Max States</th>
+                    <th scope="col">Bot Count</th>
+                    <th scope="col">Created At</th>
+                    <th scope="col">Activated At</th>
+                  </tr>
+                </thead>
+                <tbody data-role="admin-worlds-tbody"></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
 
-      <!-- Модальне вікно з поясненням задуму сайту -->
-      <div
-        class="modal"
-        id="info-modal"
-        hidden
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="info-modal-title"
-      >
-        <div class="modal__overlay" id="modal-overlay"></div>
-        <div class="modal__dialog">
-          <div class="modal__content">
-            <h2 class="modal__title" id="info-modal-title" data-i18n="aboutTitle">Про проєкт</h2>
-            <p class="modal__text" data-i18n-html="modalText">
-              Цей сайт відкриває приховану геометрію вашого життя.<br />
-              На основі дати народження народжується унікальний візерунок — візуальний відбиток вашої присутності у Всесвіті.<br />
-              Це не просто анімація, а символ початку й таємниці, який завжди буде лише вашим.
-            </p>
-            <button class="modal__close" id="modal-close" data-i18n="modalClose">Добре</button>
-          </div>
+    <!-- Модальне вікно з поясненням задуму сайту -->
+    <div
+      class="modal"
+      id="info-modal"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="info-modal-title"
+    >
+      <div class="modal__overlay" id="modal-overlay"></div>
+      <div class="modal__dialog">
+        <div class="modal__content">
+          <h2 class="modal__title" id="info-modal-title" data-i18n="aboutTitle">Про проєкт</h2>
+          <p class="modal__text" data-i18n-html="modalText">
+            Цей сайт відкриває приховану геометрію вашого життя.<br />
+            На основі дати народження народжується унікальний візерунок — візуальний відбиток вашої присутності у Всесвіті.<br />
+            Це не просто анімація, а символ початку й таємниці, який завжди буде лише вашим.
+          </p>
+          <button class="modal__close" id="modal-close" data-i18n="modalClose">Добре</button>
         </div>
       </div>
     </div>
-
     <script src="assets/js/config.js"></script>
     <script src="assets/js/utils/prng.js"></script>
     <script src="assets/js/utils/tzolkin.js"></script>


### PR DESCRIPTION
## Summary
- add shared SPA navigation with play and admin screens in the existing index
- implement client-side routing that highlights the active nav item and loads /api/admin/worlds with proper states
- style the new admin table and navigation elements within the existing theme

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b17117bfc8320ac5c389cc0d6b618)